### PR TITLE
Redirect to the docs master branch when visiting the docs root

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -37,6 +37,8 @@ jobs:
 
       - run: sphinx-multiversion docs build/html
 
+      - run: cp ./index.html ./build/html
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to master branch</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./master/index.html">
+    <link rel="canonical" href="./master/index.html">
+  </head>
+</html>


### PR DESCRIPTION
When a user visit the docs root at https://age.apache.org/docs, currently a file and directory listing is displayed. This pull request adds an index.html at the docs root which redirects to the master version of the documentation (https://age.apache.org/docs/master/index.html).