### PR TITLE
add commands to install python3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,43 @@
 
 ## Introduction
 
-* The `master` branch contains the source code of the latest version of the documentation.
-* `vX.Y.Z` Branches contain the source code of the documentation of releases.
-* The `asf-site` branch contains the static webpage code, as well as the build static version of the documenation (in the `docs` folder). The `docs` folder should not be manually updated.
+- The `master` branch contains the source code of the latest version of the documentation.
+- `vX.Y.Z` Branches contain the source code of the documentation of releases.
+- The `asf-site` branch contains the static webpage code, as well as the build static version of the documenation (in the `docs` folder). The `docs` folder should not be manually updated.
 
 ## Build the documentation locally (first time)
 
-* Install requirements (the latex and dvisvgm commands are required to display math)
+- Install requirements (the latex and dvisvgm commands are required to display math)
 
 ```shell
-sudo apt install python3 virtualenv texlive-latex-base texlive-latex-extra texlive-extra-utils
+sudo apt update
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt install texlive-latex-base texlive-latex-extra texlive-extra-utils python3.9 python3.9-venv software-properties-common
 ```
 
-* Clone this repository
-* Navigate to the root of the repository
-* Create a python virtual environment
+- Clone this repository
+- Navigate to the root of the repository
+- Create a python virtual environment
 
 ```shell
-virtualenv -p python3 venv
+virtualenv -p python3.9 venv
 ```
 
-* Activate the virtual environment
+- Activate the virtual environment
 
 ```shell
 source venv/bin/activate
 ```
 
-* Install the python requirements
+- Install the python requirements
 
 ```shell
 pip install -r requirements.txt
 ```
 
-* Build the documentation
-  * From :warning: remote branches
+- Build the documentation
+
+  - From :warning: remote branches
 
     ```shell
     sphinx-multiversion docs build/html
@@ -43,7 +46,7 @@ pip install -r requirements.txt
 
     The documentation should now be in the `build/html` folder, with a subfolder per remote branch (version).
 
-  * From the current folder
+  - From the current folder
 
     ```shell
     sphinx-build docs build/html/current
@@ -53,16 +56,17 @@ pip install -r requirements.txt
 
 ## Build documentation locally (after initial setup)
 
-* Navigate to the root of the repository
+- Navigate to the root of the repository
 
-* Activate the virtual environment if not yet active
+- Activate the virtual environment if not yet active
 
 ```shell
 source venv/bin/activate
 ```
 
-* Build the documentation
-  * From :warning: remote branches
+- Build the documentation
+
+  - From :warning: remote branches
 
     ```shell
     sphinx-multiversion docs build/html
@@ -70,7 +74,7 @@ source venv/bin/activate
 
     The documentation should now be in the `build/html` folder, with a subfolder per remote branch (version).
 
-  * From the current folder
+  - From the current folder
 
     ```shell
     sphinx-build docs build/html/current


### PR DESCRIPTION
Python3.10 does not work with Sphinx version mentioned in requirements. Commands will installed Python 3.9 and 3.9 environment packages.