### PR TITLE
Build site when new documentation is added to prevent rollback of contents on the website

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,54 +1,80 @@
-name: Build documentation
+on:
+  push:
+    branches:
+      - master
 
-on: push
-
+name: build gatsby
 jobs:
-  deploy:
-    runs-on: ubuntu-20.04
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+    - name: Checkout new-web branch
+      uses: actions/checkout@v3
+      with:
+          ref: new-web
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - run: yarn install
+    - run: yarn run build
+    - run: cp .asf.yaml ./public
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
+    - name: Deploy web
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: asf-site
+        publish_dir: ./public
+        destination_dir: ./
 
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+    - name: Checkout master branch
+      uses: actions/checkout@v3
+      with:
+          ref: master
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python3 -m pip install -r ./requirements.txt
+    - name: Fetch all branches
+      run: git fetch --all
 
-      - run: sphinx-multiversion docs build/html
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
 
-      - run: cp ./index.html ./build/html
+    - name: Upgrade pip
+      run: |
+        # install pip=>20.1 to use "pip cache dir"
+        python3 -m pip install --upgrade pip
+    - name: Get pip cache dir
+      id: pip-cache
+      run: echo "::set-output name=dir::$(pip cache dir)"
 
-      - name: Deploy-asf-site
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: asf-site
-          publish_dir: ./build/html
-          destination_dir: ./age-manual
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: python3 -m pip install -r ./requirements.txt
 
-      - name: Deploy-asf-staging
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: asf-staging
-          publish_dir: ./build/html
-          destination_dir: ./age-manual          
+    - run: sphinx-multiversion docs build/html
+
+    - run: cp ./index.html ./build/html
+
+    - name: Deploy documentation
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: asf-site
+        publish_dir: ./build/html
+        destination_dir: ./age-manual


### PR DESCRIPTION
This PR should fix #94 by rebuilding an redeploying the website when documentation is added or updated.