### PR TITLE
[doc]: Fix internal link errors

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -7,7 +7,7 @@ There are no restrictions to using Cypher with CTEs ([Common Table Expressions](
 Query:
 
 
-```
+```postgresql
 WITH graph_query as (
     SELECT *
         FROM cypher('graph_name', $$
@@ -69,7 +69,7 @@ Cypher queries using the CREATE, SET, REMOVE clauses cannot be used in sql queri
 Query:
 
 
-```
+```postgresql
 SELECT id, 
     graph_query.name = t.name as names_match,
     graph_query.age = t.age as ages_match
@@ -135,7 +135,7 @@ Cypher cannot be used in an expression, the query must exists in the FROM clause
 When writing a cypher query that is known to return 1 column and 1 row, the '=' comparison operator may be used.
 
 
-```
+```postgresql
 SELECT t.name FROM schema_name.sql_person AS t
 where t.name = (
     SELECT a
@@ -179,7 +179,7 @@ When writing a cypher query that is known to return 1 column, but may have multi
 Query:
 
 
-```
+```postgresql
 SELECT t.name, t.age FROM schema_name.sql_person as t 
 where t.name in (
     SELECT *
@@ -233,7 +233,7 @@ When writing a cypher query that may have more than 1 column and row returned. T
 Query:
 
 
-```
+```postgresql
 SELECT t.name, t.age
 FROM schema_name.sql_person as t
 WHERE EXISTS (
@@ -282,7 +282,7 @@ Results:
 There is no restriction to the number of graphs an SQL statement can query. Allowing users to query more than one graph at the same time.
 
 
-```
+```postgresql
 SELECT graph_1.name, graph_1.age, graph_2.license_number
 FROM cypher('graph_1', $$
     MATCH (v:Person)

--- a/docs/advanced/plpgsql.md
+++ b/docs/advanced/plpgsql.md
@@ -3,7 +3,7 @@
 Cypher commands can be run in [PL/pgSQL](https://www.postgresql.org/docs/11/plpgsql-overview.html) functions without restriction.
 
 Data Setup
-```
+```postgresql
 SELECT *
 FROM cypher('imdb', $$
 	CREATE (toby:actor {name: 'Toby Maguire'}),
@@ -28,7 +28,7 @@ $$) AS (a agtype);
 ```
 
 Function Creation
-```
+```postgresql
 CREATE OR REPLACE FUNCTION get_all_actor_names()
 RETURNS TABLE(actor agtype)
 LANGUAGE plpgsql
@@ -48,7 +48,7 @@ $BODY$;
 ```
 
 Query:
-```
+```postgresql
 SELECT * FROM get_all_actor_names();
 ```
 
@@ -85,7 +85,7 @@ It's recommended that the LOAD 'age' command and setting the search_path in the 
 ## Dynamic Cypher
 
 
-```
+```postgresql
 CREATE OR REPLACE FUNCTION get_actors_who_played_role(role agtype)
 RETURNS TABLE(actor agtype, movie agtype)
 LANGUAGE plpgsql
@@ -109,7 +109,7 @@ END
 $function$;
 ```
 
-```
+```postgresql
 SELECT * FROM get_actors_who_played_role('"Peter Parker"');
 ```
 

--- a/docs/advanced/prepared_statements.md
+++ b/docs/advanced/prepared_statements.md
@@ -14,7 +14,7 @@ Example: <code>$<strong>parameter_name</strong></code>
 Preparing Prepared Statements in cypher is an extension of Postgres' stored procedure system. Use the PREPARE clause to create a query with the Cypher Function call in it. Do not place Postgres style parameters in the cypher query call, instead place Cypher parameters in the query and place a Postgres parameter as the third argument in the Cypher function call.
 
 
-```
+```postgresql
 PREPARE cypher_stored_procedure(agtype) AS
 SELECT *
 FROM cypher('expr', $$
@@ -30,7 +30,7 @@ AS (v agtype);
 When executing the prepared statement, place an agtype map with the parameter values where the Postgres Parameter in the Cypher function call is. The value must be an agtype map or an error will be thrown. Exclude the '$' for parameter names.
 
 
-```
+```postgresql
 EXECUTE cypher_prepared_statement('{"name": "Tobias"}');
 ```
 

--- a/docs/advanced/prepared_statements.md
+++ b/docs/advanced/prepared_statements.md
@@ -1,6 +1,6 @@
 # Prepared Statements
 
-Cypher can run a read query within a Prepared Statement. When using parameters with stored procedures, An SQL Parameter must be placed in the cypher function call. See The [AGE Query Format](#the-age-cypher-query-format) for details.
+Cypher can run a read query within a Prepared Statement. When using parameters with stored procedures, An SQL Parameter must be placed in the cypher function call. See The [AGE Query Format](../intro/cypher.md#the-age-cypher-query-format) for details.
 
 ## Cypher Parameter Format
 

--- a/docs/advanced/sql_in_cypher.md
+++ b/docs/advanced/sql_in_cypher.md
@@ -1,6 +1,6 @@
 # SQL In Cypher
 
-AGE does not support SQL being directly written in Cypher. However with [user defined functions](../functions/user_functions#) you can write sql queries and call them in a cypher command.
+AGE does not support SQL being directly written in Cypher. However with [user defined functions](../functions/user_functions.md) you can write sql queries and call them in a cypher command.
 
 
 ```

--- a/docs/advanced/sql_in_cypher.md
+++ b/docs/advanced/sql_in_cypher.md
@@ -11,7 +11,7 @@ Void and Scalar-Value functions only. Set returning functions are not currently 
 
 
 ## Create Function
-```
+```postgresql
 CREATE OR REPLACE FUNCTION public.get_event_year(name agtype) RETURNS agtype AS $$
 	SELECT year::agtype
 	FROM history AS h
@@ -21,7 +21,7 @@ $$ LANGUAGE sql;
 ```
 
 ## Query
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (e:event)
 	WHERE e.year < public.get_event_year(e.name)

--- a/docs/clauses/create.md
+++ b/docs/clauses/create.md
@@ -10,7 +10,7 @@ A create clause that is not followed by another clause is called a terminal clau
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE /* Create clause here, no following clause */
@@ -37,7 +37,7 @@ Creating a single vertex is done by issuing the following query.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE (n)
@@ -68,7 +68,7 @@ Creating multiple vertices is done by separating them with a comma.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE (n), (m)
@@ -99,7 +99,7 @@ To add a label when creating a vertex, use the syntax below.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE (:Person)
@@ -132,7 +132,7 @@ When creating a new vertex with labels, you can add properties at the same time.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE (:Person {name: 'Andres', title: 'Developer')
@@ -165,7 +165,7 @@ Creating a single node is done by issuing the following query.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE (a {name: 'Andres')
@@ -201,7 +201,7 @@ To create an edge between two vertices, we first get the two vertices. Once the 
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     MATCH (a:Person), (b:Person)
@@ -241,7 +241,7 @@ Setting properties on edges is done in a similar manner to how it’s done when 
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     MATCH (a:Person), (b:Person)
@@ -281,7 +281,7 @@ When you use CREATE and a pattern, all parts of the pattern that are not already
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     CREATE p = (andres {name:'Andres'})-[:WORKS_AT]->(neo)<-[:WORKS_AT]-(michael {name:'Michael'})

--- a/docs/clauses/delete.md
+++ b/docs/clauses/delete.md
@@ -21,7 +21,7 @@ To delete a vertex, use the DELETE clause.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
 	MATCH (v:Useless)
@@ -51,7 +51,7 @@ Running a Match clause will collect all nodes, use the DETACH option to first de
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
 	MATCH (v:Useless)
@@ -79,7 +79,7 @@ Nothing is returned from this query.
 To delete an edge, use the match clause to find your edges, then add the variable to the DELETE.
 
 Query
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
 	MATCH (n {name: 'Andres'})-[r:KNOWS]->()
@@ -107,7 +107,7 @@ Nothing is returned from this query.
 In AGE, you can return vertices that have been deleted.
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n {name: 'A'})

--- a/docs/clauses/limit.md
+++ b/docs/clauses/limit.md
@@ -14,7 +14,7 @@ To return a subset of the result, starting from the top, use this syntax:
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
 	MATCH (n)RETURN n.name
@@ -59,7 +59,7 @@ Limit accepts any expression that evaluates to a positive integer as long as it 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n)

--- a/docs/clauses/match.md
+++ b/docs/clauses/match.md
@@ -18,7 +18,7 @@ By just specifying a pattern with a single vertex and no labels, all vertices in
 
 Query
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (v)
 RETURN v
@@ -77,7 +77,7 @@ Getting all vertices with a label on them is done with a single node pattern whe
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (movie:Movie)
 RETURN movie.title
@@ -116,7 +116,7 @@ The symbol -[]- means related to, without regard to type or direction of the edg
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (director {name: 'Oliver Stone'})-[]-(movie)
 RETURN movie.title
@@ -151,7 +151,7 @@ To constrain your pattern with labels on vertices, you add it to your vertex in 
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (:Person {name: 'Oliver Stone'})-[]-(movie:Movie)
 RETURN movie.title
@@ -189,7 +189,7 @@ When the direction of an edge is of interest, it is shown by using -> or &lt;-.
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (:Person {name: 'Oliver Stone'})-[]->(movie)
 RETURN movie.title
@@ -224,7 +224,7 @@ If a variable is required, either for filtering on properties of the edge, or to
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (:Person {name: 'Oliver Stone'})-[r]->(movie)
 RETURN type(r)
@@ -259,7 +259,7 @@ When you know the edge type you want to match on, you can specify it by using a 
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH (:Movie {title: 'Wall Street'})<-[:ACTED_IN]-(actor)
 RETURN actor.name
@@ -302,7 +302,7 @@ If you both want to introduce a variable to hold the edge, and specify the edge 
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MATCH ({title: 'Wall Street'})<-[r:ACTED_IN]-(actor)
 RETURN r.role
@@ -345,7 +345,7 @@ Edges can be expressed by using multiple statements in the form of ()-[]-(), or 
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
     MATCH (charlie {name: 'Charlie Sheen'})-[:ACTED_IN]->(movie)<-[:DIRECTED]-(director)
     RETURN movie.title, director.name
@@ -437,7 +437,7 @@ Returns all paths between u and v
 Query
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
     MATCH p = (actor {name: 'Willam Defoe'})-[:ACTED_IN*2]-(co_actor)
     RETURN relationships(p)

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -11,7 +11,7 @@ As with MATCH, MERGE can match multiple occurrences of a pattern. If there are m
 
 ## Data Setup
 
-```
+```postgresql
 SELECT * from cypher('graph_name', $$
 CREATE (A:Person {name: "Charlie Sheen", bornIn: "New York"}),
     (B:Person {name: "Michael Douglas", bornIn: "New Jersey"}),
@@ -30,7 +30,7 @@ By just specifying a pattern with a single vertex and no labels, all vertices in
 
 Query
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MERGE (v:Critic)
 RETURN v
@@ -61,7 +61,7 @@ Merging a vertex node with properties where not all properties match any existin
 
 Query
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MERGE (charlie {name: 'Charlie Sheen', age: 10})
 RETURN charlie
@@ -94,7 +94,7 @@ Merging a vertex where both label and property constraints match an existing ver
 
 Query
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 MERGE (michael:Person {name: 'Michael Douglas'})
 RETURN michael.name, michael.bornIn

--- a/docs/clauses/order_by.md
+++ b/docs/clauses/order_by.md
@@ -18,7 +18,7 @@ ORDER BY is used to sort the output.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)
@@ -74,7 +74,7 @@ You can order by multiple properties by stating each variable in the ORDER BY cl
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)
@@ -130,7 +130,7 @@ By adding DESC[ENDING] after the variable to sort on, the sort will be done in r
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)
@@ -186,7 +186,7 @@ When sorting the result set, null will always come at the end of the result set 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)

--- a/docs/clauses/remove.md
+++ b/docs/clauses/remove.md
@@ -15,7 +15,7 @@ Cypher doesn’t allow storing null in properties. Instead, if no value exists, 
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     MATCH (andres {name: 'Andres'})

--- a/docs/clauses/return.md
+++ b/docs/clauses/return.md
@@ -10,7 +10,7 @@ To return a node, list it in the RETURN statement.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'B'})
@@ -48,7 +48,7 @@ To return n edge, just include it in the RETURN list.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)-[r:KNOWS]->()
@@ -85,7 +85,7 @@ To return a property, use the dot separator, like this:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})
@@ -121,7 +121,7 @@ When you want to return all vertices, edges and paths found in a query, you can 
 
 Query
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (a {name: 'A'})-[r]->(b)
@@ -175,7 +175,7 @@ To introduce a placeholder that is made up of characters that are not contained 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (`This isn\'t a common variable`)
@@ -214,7 +214,7 @@ If the name of the field should be different from the expression used, you can r
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})
@@ -252,7 +252,7 @@ If a property might or might not be there, you can still select it as usual. It 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n)
@@ -294,7 +294,7 @@ Any expression can be used as a return item—literals, predicates, properties, 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (a)
@@ -340,7 +340,7 @@ DISTINCT retrieves only unique records depending on the fields that have been se
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 MATCH (a {name: 'A'})-[]->(b)

--- a/docs/clauses/set.md
+++ b/docs/clauses/set.md
@@ -15,7 +15,7 @@ To set a property on a node or relationship, use SET.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
    MATCH (v {name: 'Andres'})
@@ -49,7 +49,7 @@ Creating a single vertex is done by issuing the following query.
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     MATCH (v {name: 'Andres'})
@@ -88,7 +88,7 @@ Normally you remove a property by using REMOVE, but it’s sometimes handy to do
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
     MATCH (v {name: 'Andres'})
@@ -126,7 +126,7 @@ If you want to set multiple properties in one go, simply separate them with a co
 Query
 
 
-```
+```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
 MATCH (v {name: 'Andres'})

--- a/docs/clauses/skip.md
+++ b/docs/clauses/skip.md
@@ -13,7 +13,7 @@ To return a subset of the result, starting from the top, use this syntax:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n)
@@ -55,7 +55,7 @@ To return a subset of the result, starting from somewhere in the middle, use thi
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n)
@@ -97,7 +97,7 @@ Using an expression with SKIP to return a subset of the rows
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n)

--- a/docs/clauses/with.md
+++ b/docs/clauses/with.md
@@ -14,7 +14,7 @@ WITH is also used to separate the reading of the graph from updating of the grap
 Aggregated results have to pass through a WITH clause to be able to filter on.
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (david {name: 'David'})-[]-(otherPerson)-[]->()
@@ -54,7 +54,7 @@ Result
 You can sort your results before passing them to collect, thus sorting the resulting list.
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n)WITH n
@@ -92,7 +92,7 @@ You can match paths, limit to a certain number, and then match again using those
 
 Query
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (n {name: 'Anders'})-[]-(m)WITH m

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,14 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 pygments_style = 'sphinx'
 
 
+# -- Options for MYST configuration -------------------------------------------------
+
+# This option tells myst_parser to generate labels for heading anchors
+# for h1, h2, and h3 level headings (corresponding to #, ##, and ### in
+# markdown)
+myst_heading_anchors = 3
+
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/functions/aggregate_functions.md
+++ b/docs/functions/aggregate_functions.md
@@ -3,7 +3,7 @@
 Functions that activate [auto aggregation](../intro/aggregation.md).
 
 ## Data Setup
-```
+```postgresql
 LOAD 'age';
 SET search_path TO ag_catalog;
 
@@ -69,7 +69,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (v:Person)
@@ -105,7 +105,7 @@ Data Setup:
 To clarify the following example, assume the next three commands are run first:
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$ 
     CREATE (:min_test {val:'d'})
 $$) as (result agtype);
@@ -123,7 +123,7 @@ $$) as (result agtype);
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (v:min_test)
@@ -199,7 +199,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
@@ -273,7 +273,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
    MATCH (n:Person)
@@ -347,7 +347,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
@@ -427,7 +427,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
@@ -507,7 +507,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
@@ -585,7 +585,7 @@ Considerations:
 
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})-[]->(x)
@@ -619,7 +619,7 @@ Result:
 Using count(*) to group and count relationship typescount(*) can be used to group relationship types and return the number.
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})-[r]->()
@@ -661,7 +661,7 @@ Instead of simply returning the number of records with count(*), it may be more 
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})-[]->(x)
@@ -699,7 +699,7 @@ count(expression) can be used to return the number of non-null values returned b
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
@@ -736,7 +736,7 @@ In this example we are trying to find all our friends of friends, and count them
 * The second aggregate function, count(friend_of_friend), will consider the same friend_of_friend multiple times.
 
 Query
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (me:Person)-[]->(friend:Person)-[]->(friend_of_friend:Person)
@@ -811,7 +811,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 MATCH (n:Person)
@@ -885,7 +885,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 MATCH (n:Person)

--- a/docs/functions/aggregate_functions.md
+++ b/docs/functions/aggregate_functions.md
@@ -1,6 +1,6 @@
 # Aggregation Functions
 
-Functions that activate [auto aggregation](../intro/aggregation#).
+Functions that activate [auto aggregation](../intro/aggregation.md).
 
 ## Data Setup
 ```

--- a/docs/functions/list_functions.md
+++ b/docs/functions/list_functions.md
@@ -2,7 +2,7 @@
 
 ## Data Setup
 
-```
+```postgresql
 SELECT * from cypher('graph_name', $$
 CREATE (A:Person {name: 'Alice', age: 38, eyes: 'brown'}),
 	(B:Person {name: 'Bob', age: 25, eyes: 'blue'}),
@@ -48,7 +48,7 @@ Considerations:
 * keys(null) returns null.
 
 Query:
-```
+```postgresql
 SELECT * from cypher('graph_name', $$
 	MATCH (a)
 	WHERE a.name = 'Alice'
@@ -115,7 +115,7 @@ Arguments:
 </table>
 
 Query:
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	RETURN range(0, 10), range(2, 18, 3)
@@ -173,7 +173,7 @@ Considerations:
 * labels(null) returns null.
 
 Query:
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (a)
@@ -231,7 +231,7 @@ Considerations:
 * relationships(null) returns null.
 
 Query:
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH p = (a)-[]->(b)-[]->(c)

--- a/docs/functions/logarithmic_functions.md
+++ b/docs/functions/logarithmic_functions.md
@@ -18,7 +18,7 @@ An agtype float.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN e()
@@ -63,7 +63,7 @@ An agtype float.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN sqrt(144)
@@ -133,7 +133,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN e(2)
@@ -206,7 +206,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN log(27)
@@ -279,7 +279,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN log(27)

--- a/docs/functions/numeric_functions.md
+++ b/docs/functions/numeric_functions.md
@@ -18,7 +18,7 @@ A Float.
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN rand()
@@ -91,7 +91,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (a), (e) WHERE a.name = 'Alice' AND e.name = 'Eskil'
@@ -172,7 +172,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN ceil(0.1)
@@ -246,7 +246,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN floor(0.1)
@@ -320,7 +320,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN round(3.141592)
@@ -388,7 +388,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN sign(-17), sign(0.1), sign(0)

--- a/docs/functions/predicate_functions.md
+++ b/docs/functions/predicate_functions.md
@@ -35,7 +35,7 @@ Arguments:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
      MATCH (n)
@@ -78,7 +78,7 @@ Results:
 
 EXISTS(path) returns true if for the given path, there already exists the given path.
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
      MATCH (n)

--- a/docs/functions/scalar_functions.md
+++ b/docs/functions/scalar_functions.md
@@ -39,7 +39,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (a)
@@ -118,7 +118,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH ()-[e]->()
@@ -195,7 +195,7 @@ Arguments:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH ()-[e]->()
@@ -274,7 +274,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH ()-[e]->()
@@ -345,7 +345,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     CREATE (p:Person {name: 'Stefan', city: 'Berlin'})
@@ -417,7 +417,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
    MATCH (a)
@@ -496,7 +496,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 MATCH (a)
@@ -570,7 +570,7 @@ Considerations:length(null) returns null.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
    MATCH p = (a)-[]->(b)-[]->(c)
@@ -652,7 +652,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN size(['Alice', 'Bob'])
@@ -724,7 +724,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (x:Developer)-[r]-()
@@ -799,7 +799,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     MATCH (x:Developer)-[r]-()
@@ -855,7 +855,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN timestamp()
@@ -929,7 +929,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN toBoolean('TRUE'), toBoolean('not a boolean')
@@ -997,7 +997,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN toFloat('11.5'), toFloat('not a number')
@@ -1073,7 +1073,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
      RETURN toInteger('42'), toInteger('not a number')
@@ -1147,7 +1147,7 @@ Considerations:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 MATCH (a)

--- a/docs/functions/string_functions.md
+++ b/docs/functions/string_functions.md
@@ -63,7 +63,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	RETURN replace('hello', 'l', 'w')
@@ -139,7 +139,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN split('one,two', ',')
@@ -218,7 +218,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	RETURN left('Hello', 3)
@@ -297,7 +297,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN right('hello', 3)
@@ -384,7 +384,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN substring('hello', 1, 3), substring('hello', 2)
@@ -458,7 +458,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN rTrim(' hello ')
@@ -528,7 +528,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN lTrim(' hello ')
@@ -598,7 +598,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN trim(' hello ')
@@ -668,7 +668,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN toLower('HELLO')
@@ -738,7 +738,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN toUpper('hello')
@@ -808,7 +808,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN reverse("hello")
@@ -879,7 +879,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN toString(11.5),toString('a string'), toString(true)

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -43,7 +43,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN degrees(3.14159)
@@ -115,7 +115,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN radians(180)
@@ -162,7 +162,7 @@ An agtype float.
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN pi()
@@ -234,7 +234,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN sin(0.5)
@@ -306,7 +306,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN cosin(0.5)
@@ -378,7 +378,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN tan(0.5)
@@ -451,7 +451,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN asin(0.5)
@@ -524,7 +524,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN acos(0.5)
@@ -596,7 +596,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN atan(0.5)
@@ -674,7 +674,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN atan2(0.5, 0.6)

--- a/docs/functions/user_functions.md
+++ b/docs/functions/user_functions.md
@@ -7,7 +7,7 @@ Syntax: `namespace_name.function_name`
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 RETURN pg_catalog.sqrt(25)

--- a/docs/intro/aggregation.md
+++ b/docs/intro/aggregation.md
@@ -9,7 +9,7 @@ In a regular aggregation (i.e. of the form aggr(expr)), the list of aggregated v
 
 ## Data Setup
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	CREATE (a:Person {name: 'A', age: 13}),
 	(b:Person {name: 'B', age: 33, eyes: "blue"}),
@@ -32,7 +32,7 @@ Aggregating functions take a  set of values and calculate An aggregated value ov
 Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the valuesgoing into the aggregate functions.
 
 Assume we have the following return statement:
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	RETURN v.name, count(*)
@@ -72,7 +72,7 @@ We have two return expressions: grouping_key, and count(*). The first, grouping_
 
 To use aggregations to sort the result set, the aggregation must be included in the RETURN to be used in the ORDER BY.
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (me:Person)-[]->(friend:Person)
@@ -87,7 +87,7 @@ In a distinct aggregation (i.e. of the form aggr(DISTINCT expr)), the list of ag
 
 The DISTINCT operator works in conjunction with aggregation. It is used to make all values unique before running them  through an aggregate function.
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	MATCH (v:Person)
@@ -114,7 +114,7 @@ $$) as (distinct_eyes agtype, eyes agtype);
 This feature of not requiring the user to specifiy their grouping keys for a query allows for ambiguity on what Cypher should qualify as their grouping keys. For more details [click here.](https://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/)
 
 Data Setup 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 CREATE (:L {a: 1, b: 2, c: 3}),
        (:L {a: 2, b: 3, c: 1}),
@@ -128,7 +128,7 @@ AGE's solution to this problem is to not allow a WITH or RETURN column to combin
 
 
 Query:
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (x:L)
 	RETURN x.a + count(*) + x.b + count(*) + x.c
@@ -136,7 +136,7 @@ $$) as (a agtype);
 ```
 
 Result:
-```
+```postgresql
 ERROR:  "x" must be either part of an explicitly listed key or used inside an aggregate function
 LINE 3: RETURN x.a + count(*) + x.b + count(*) + x.c
 ```
@@ -148,7 +148,7 @@ Columns that do not include an aggregate function in AGE are considered to be th
 For the above query, the user could rewrite the query is several ways that will return results
 
 Query:
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (x:L)
 	RETURN (x.a + x.b + x.c) + count(*) + count(*), x.a + x.b + x.c
@@ -175,7 +175,7 @@ Results
 
 
 Query
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (x:L)
 	RETURN x.a + count(*) + x.b + count(*) + x.c, x.a, x.b, x.c
@@ -222,7 +222,7 @@ Results:
 
 Alternatively, the grouping key can be a vertex or edge, and then any properties of the vertex or edge can be specified without being explicitly stated in a WITH or RETURN column.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (x:L)
 	RETURN count(*) + count(*) + x.a + x.b + x.c, x
@@ -261,7 +261,7 @@ Results
 
 If the grouping key is considered unecessary for the query output, the aggregation can be done in a WITH clause then passing information to the RETURN clause.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (x:L)
 	WITH count(*) + count(*) + x.a + x.b + x.c as column, x

--- a/docs/intro/aggregation.md
+++ b/docs/intro/aggregation.md
@@ -3,7 +3,7 @@
 
 ## Introduction 
 
-Generally an aggregation aggr(expr) processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.html#)).
+Generally an aggregation aggr(expr) processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.md)).
 
 In a regular aggregation (i.e. of the form aggr(expr)), the list of aggregated values is the list of candidate values with all null values removed from it.
 
@@ -27,7 +27,7 @@ $$) as (a agtype);
 ## Auto Group By
 To calculate aggregated data, Cypher offers aggregation, analogous to SQL’s GROUP BY.
 
-Aggregating functions take a  set of values and calculate An aggregated value over them. Examples are [avg()](../functions/aggregate_functions.html#avg) that calculates the average of multiple numeric values, or [min()](../functions/aggregate_functions.html#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression(such as n.age) to all the records within the same aggregation group.
+Aggregating functions take a  set of values and calculate An aggregated value over them. Examples are [avg()](../functions/aggregate_functions.md#avg) that calculates the average of multiple numeric values, or [min()](../functions/aggregate_functions.md#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression(such as n.age) to all the records within the same aggregation group.
 
 Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the valuesgoing into the aggregate functions.
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -17,7 +17,7 @@ Following are the details about the functions to create vertices and edges from 
 
 function `load_labels_from_file` is used to load vertices from the CSV files. 
 
-```sql
+```postgresql
 load_labels_from_file('<graph name>', 
                       '<label name>',
                       '<file path>')
@@ -25,7 +25,7 @@ load_labels_from_file('<graph name>',
 
 By adding the fourth parameter user can exclude the id field. *** Use this when there is no id field in the file***
 
-```sql
+```postgresql
 load_labels_from_file('<graph name>', 
                       '<label name>',
                       '<file path>', 
@@ -36,7 +36,7 @@ Function `load_edges_from_file` can be used to load properties from the CSV file
 
 Note: make sure that ids in the edge file are identical to ones that are in vertices files. 
 
-```sql
+```postgresql
 oad_edges_from_file('<graph name>',
                     '<label name>',
                     '<file path>');
@@ -67,7 +67,7 @@ example files can be viewed at `regress/age_load/data`
 ## Example SQL script 
 
 - Load and create graph 
-```sql
+```postgresql
 LOAD 'age';
 
 SET search_path TO ag_catalog;
@@ -76,7 +76,7 @@ SELECT create_graph('agload_test_graph');
 
 - Create label `country` and load vertices from csv file. *** Note this CSV file has id field ***
 
-```sql
+```postgresql
 SELECT create_vlabel('agload_test_graph','Country');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country',
@@ -85,7 +85,7 @@ SELECT load_labels_from_file('agload_test_graph',
 
 - Create label `City` and load vertices from csv file. *** Note this CSV file has id field ***
 
-```sql
+```postgresql
 SELECT create_vlabel('agload_test_graph','City');
 SELECT load_labels_from_file('agload_test_graph',
                              'City', 
@@ -94,7 +94,7 @@ SELECT load_labels_from_file('agload_test_graph',
 
 - Create label `has_city` and load edges from csv file.
 
-```sql
+```postgresql
 SELECT create_elabel('agload_test_graph','has_city');
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/edges.csv');
@@ -102,7 +102,7 @@ SELECT load_edges_from_file('agload_test_graph', 'has_city',
 
 - check if the graph has been loaded properly
 
-```sql
+```postgresql
 SELECT table_catalog, table_schema, table_name, table_type
 FROM information_schema.tables
 WHERE table_schema = 'agload_test_graph';
@@ -119,7 +119,7 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
 
 - Create label `country` and load vertices from csv file. *** Note this CSV file has no id field ***
 
-```sql
+```postgresql
 SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country2',
@@ -128,7 +128,7 @@ SELECT load_labels_from_file('agload_test_graph',
 ```
 
 - Create label `City` and load vertices from csv file. *** Note this CSV file has id field ***
-```sql
+```postgresql
 SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph',
                              'City2',
@@ -139,7 +139,7 @@ SELECT load_labels_from_file('agload_test_graph',
 
 - labels `country` and `city` were created with id field in the file
 - labels `country2` and `city2` were created with no id field in the file. 
-```sql
+```postgresql
 SELECT COUNT(*) FROM agload_test_graph."Country2";
 SELECT COUNT(*) FROM agload_test_graph."City2";
 

--- a/docs/intro/cypher.md
+++ b/docs/intro/cypher.md
@@ -63,7 +63,7 @@ $$) AS (result1 agtype, result2 agtype);
 
 ## Cypher in an Expression
 
-Cypher may not be used as part of an expression, use a subquery instead. See [Advanced Cypher Queries](../advanced/advanced.html#cypher-in-sql-expressions) for information about how to use Cypher queries with Expressions
+Cypher may not be used as part of an expression, use a subquery instead. See [Advanced Cypher Queries](../advanced/advanced.md#cypher-in-sql-expressions) for information about how to use Cypher queries with Expressions
 
 
 ## SELECT Clause

--- a/docs/intro/cypher.md
+++ b/docs/intro/cypher.md
@@ -55,7 +55,7 @@ Considerations:
 Query:
 
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$ 
 /* Cypher Query Here */ 
 $$) AS (result1 agtype, result2 agtype);
@@ -73,7 +73,7 @@ Calling Cypher in the SELECT clause as an independent column is not allowed. How
 Not Allowed:
 
 
-```
+```postgresql
 SELECT 
     cypher('graph_name', $$
          MATCH (v:Person)

--- a/docs/intro/graphs.md
+++ b/docs/intro/graphs.md
@@ -46,7 +46,7 @@ Considerations
 
 Example:
 
-```
+```postgresql
 SELECT * FROM ag_catalog.create_graph('graph_name');
 ```
 
@@ -99,7 +99,7 @@ Considerations:
 
 Example:
 
-```
+```postgresql
 SELECT * FROM ag_catalog.drop_graph('graph_name', true);
 ```
 

--- a/docs/intro/operators.md
+++ b/docs/intro/operators.md
@@ -4,7 +4,7 @@
 
 ### Data Setup
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 CREATE (:Person {name: 'John'}),
        (:Person {name: 'Jeff'}),
@@ -17,7 +17,7 @@ $$) AS (result agtype);
 
 Performs case-sensitive prefix searching on strings.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name STARTS WITH "J"
@@ -50,7 +50,7 @@ Results
 
 Performs case-sensitive inclusion searching in strings.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name CONTAINS "o"
@@ -81,7 +81,7 @@ Results
 
 Performs case-sensitive suffix searching on strings.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name ENDS WITH "n"
@@ -116,7 +116,7 @@ AGE supports the use of [POSIX regular expressions](https://www.postgresql.org/d
 
 The =~ operator when no special characters are give, act like the = operator.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ 'John'
@@ -141,9 +141,9 @@ Results
 
 #### Case insensitive search
 
-Adding (?i) at the beginning of the striong will make the comparison case insensitive
+Adding (?i) at the beginning of the string will make the comparison case insensitive
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ '(?i)JoHn'
@@ -170,7 +170,7 @@ $$) AS (names agtype);
 
 The . operator acts as a wildcard to match any single character.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ 'Jo.n'
@@ -199,7 +199,7 @@ $$) AS (names agtype);
 
 The * wildcard after a character will match to 0 or more of the previous character
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ 'Johz*n'
@@ -226,7 +226,7 @@ $$) AS (names agtype);
 
 The + operator matches to 1 or more the previous character.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ 'Bil+'
@@ -253,7 +253,7 @@ Results
 
 You can use the . and * wildcards together to represent the rest of a string.
 
-```
+```postgresql
 SELECT * FROM cypher('graph_name', $$
 	MATCH (v:Person)
 	WHERE v.name =~ 'J.*'

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -373,15 +373,7 @@ Result:
 
 ### List
 
-All examples will use the 
-
-<p id="gdcalert1" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: undefined internal link (link text: "WITH"). Did you generate a TOC? </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert2">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-[WITH](#heading=h.61g87t1b908v) clause and 
-
-<p id="gdcalert2" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: undefined internal link (link text: "RETURN"). Did you generate a TOC? </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert3">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-[RETURN](#heading=h.a8dh3jonzaxn) clause.
+All examples will use the [WITH](../clauses/with.md) clause and [RETURN](../clauses/return.md) clause.
 
 
 #### Lists in general
@@ -964,11 +956,7 @@ A label is an identifier that classifies vertices and edges into certain categor
 * Edges are required to have a label, but vertices do not. 
 * The names of labels between vertices and edges cannot overlap. 
 
-See 
-
-<p id="gdcalert3" ><span style="color: red; font-weight: bold">>>>>>  gd2md-html alert: undefined internal link (link text: "CREATE"). Did you generate a TOC? </span><br>(<a href="#">Back to top</a>)(<a href="#gdcalert4">Next alert</a>)<br><span style="color: red; font-weight: bold">>>>>> </span></p>
-
-[CREATE](#heading=h.vo9azwq6syoh) clause for information about how to make entities with labels.
+See [CREATE](../clauses/create.md) clause for information about how to make entities with labels.
 
 
 ### Properties

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -15,7 +15,7 @@ Input/Output Format
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN NULL
@@ -60,7 +60,7 @@ Input/Output Format
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN 1
@@ -127,7 +127,7 @@ To use a float, denote a decimal value.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN 1.0
@@ -193,7 +193,7 @@ When creating a numeric data type, the ‘::numeric’ data annotation is requir
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN 1.0::numeric
@@ -234,7 +234,7 @@ Input/Output Format
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN TRUE
@@ -340,7 +340,7 @@ Use single (‘) quotes to identify a string. The output will use double (“) q
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     RETURN 'This is a string'
@@ -383,7 +383,7 @@ A literal list is created by using brackets and separating the elements in the l
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -419,7 +419,7 @@ A list can hold the value null, unlike when a null is an independent value, it w
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [null] as lst
@@ -455,7 +455,7 @@ To access individual elements in the list, we use the square brackets again. Thi
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -489,7 +489,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
    WITH [0, {key: 'key_value'}, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -523,7 +523,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
    WITH [0, {key: 'key_value'}, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -559,7 +559,7 @@ You can also use negative numbers, to start from the end of the list instead.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -595,7 +595,7 @@ Finally, you can use ranges inside the brackets to return ranges of the list.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -629,7 +629,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -663,7 +663,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -697,7 +697,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -730,7 +730,7 @@ Out-of-bound slices are simply truncated, but out-of-bound single elements retur
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -761,7 +761,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as lst
@@ -802,7 +802,7 @@ You can construct a simple map with simple agtypes
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH {int_key: 1, float_key: 1.0, numeric_key: 1::numeric, bool_key: true, string_key: 'Value'} as m
@@ -838,7 +838,7 @@ A map can also contain Composite Data Types, i.e. lists and other maps.
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH {listKey: [{inner: 'Map1'}, {inner: 'Map2'}], mapKey: {i: 0}} as m
@@ -872,7 +872,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH {int_key: 1, float_key: 1.0, numeric_key: 1::numeric, bool_key: true, string_key: 'Value'} as m
@@ -906,7 +906,7 @@ Result:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
     WITH {listKey: [{inner: 'Map1'}, {inner: 'Map2'}], mapKey: {i: 0}} as m
@@ -1016,7 +1016,7 @@ Data Format:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	WITH {id: 0, label: "label_name", properties: {i: 0}}::vertex as v
@@ -1106,7 +1106,7 @@ Output:
 Query
 
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	WITH {id: 2, start_id: 0, end_id: 1, label: "label_name", properties: {i: 0}}::edge as e
@@ -1147,7 +1147,7 @@ A path is a series of alternating vertices and edges. A path must start with a v
 
 Query
 
-```
+```postgresql
 SELECT *
 FROM cypher('graph_name', $$
 	WITH [{id: 0, label: "label_name_1", properties: {i: 0}}::vertex,


### PR DESCRIPTION
### What I did 
- Fixed internal link errors, bad hyperlinks and postgresql syntax highlighting.

### How I did it
- Replaced `#`,`html` fragments with `.md` files.
- Added a configuration option for myst_parser to generate labels for heading anchors for h1, h2, and h3 level headings (corresponding to #, ##, and ### in markdown).

### How to verify it
- Tested the build locally with modified files.
```bash
sphinx-build docs build/html/current
Running Sphinx v5.2.3
making output directory... done
WARNING: The config value `smv_tag_whitelist' has type `NoneType', defaults to `str'.
myst v0.18.1: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=[], disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, highlight_code_blocks=True, number_code_blocks=[], title_to_header=False, heading_anchors=3, heading_slug_func=None, footnote_transition=True, words_per_minute=200, sub_delimiters=('{', '}'), linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area')
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 37 source files that are out of date
updating environment: [new config] 37 added, 0 changed, 0 removed
reading sources... [100%] intro/types                                                                                                                                  
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/taha-linux/Desktop/age-website/docs/intro/precedence.md: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] intro/types                                                                                                                                   
generating indices... genindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in build/html/current.
```
---
- Resolves #91 
