### PR TITLE
seems a typo 

### DIFF
--- a/docs/intro/operators.md
+++ b/docs/intro/operators.md
@@ -141,7 +141,7 @@ Results
 
 #### Case insensitive search
 
-Adding (?i) at the beginning of the striong will make the comparison case insensitive
+Adding (?i) at the beginning of the string will make the comparison case insensitive
 
 ```
 SELECT * FROM cypher('graph_name', $$


### PR DESCRIPTION
I think it is a typo in the documentation section  "Operators" under case insensitive search heading
Which looks odd.
![typo](https://user-images.githubusercontent.com/63642648/208281814-51f14f57-4043-4b7f-88ac-ec593ba276c6.png)
