### PR TITLE
Fix typo in the function "load_edges_from_file"

### DIFF
--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -37,7 +37,7 @@ Function `load_edges_from_file` can be used to load properties from the CSV file
 Note: make sure that ids in the edge file are identical to ones that are in vertices files. 
 
 ```postgresql
-oad_edges_from_file('<graph name>',
+load_edges_from_file('<graph name>',
                     '<label name>',
                     '<file path>');
 ```


### PR DESCRIPTION
Fixed the typo in function as per the function found in AGE/src/backend/utils/load/age_load.c at line number 247.