### PR TITLE
Updated Syntax of Create vertex and add labels and properties

### DIFF
--- a/docs/clauses/create.md
+++ b/docs/clauses/create.md
@@ -135,7 +135,7 @@ Query
 ```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
-    CREATE (:Person {name: 'Andres', title: 'Developer')
+    CREATE (:Person {name: 'Andres', title: 'Developer'})
 $$) as (n agtype);
 ```
 


### PR DESCRIPTION
'}' was missing from Syntax of Create vertex and add labels and properties. I have corrected this.