### PR TITLE
Correcting arguments type of size() function for consistency

### DIFF
--- a/docs/functions/scalar_functions.md
+++ b/docs/functions/scalar_functions.md
@@ -614,7 +614,7 @@ Results:
 
 size() returns the length of a list.
 
-Syntax:`size(path)`
+Syntax:`size(list)`
 
 Returns:
 

--- a/docs/intro/operators.md
+++ b/docs/intro/operators.md
@@ -141,7 +141,7 @@ Results
 
 #### Case insensitive search
 
-Adding (?i) at the beginning of the striong will make the comparison case insensitive
+Adding (?i) at the beginning of the string will make the comparison case insensitive
 
 ```
 SELECT * FROM cypher('graph_name', $$


### PR DESCRIPTION
As it was mentioned in argument section of size() function that its list which is passed as an argument to this function but in syntax section 'path' was written as an argument for size function so to maintain consistency this should be same in both sections.

![image](https://user-images.githubusercontent.com/63642648/213773638-b3513dda-e12f-4828-9854-a4c8c13ccc84.png)
