### PR TITLE
Renaming resulting column for query of rand() Numeric function 

### DIFF
--- a/docs/functions/numeric_functions.md
+++ b/docs/functions/numeric_functions.md
@@ -22,7 +22,7 @@ Query:
 SELECT *
 FROM cypher('graph_name', $$
     RETURN rand()
-$$) as (r agtype);
+$$) as (random agtype);
 ```
 
 

--- a/docs/functions/scalar_functions.md
+++ b/docs/functions/scalar_functions.md
@@ -614,7 +614,7 @@ Results:
 
 size() returns the length of a list.
 
-Syntax:`size(path)`
+Syntax:`size(list)`
 
 Returns:
 

--- a/docs/intro/operators.md
+++ b/docs/intro/operators.md
@@ -141,7 +141,7 @@ Results
 
 #### Case insensitive search
 
-Adding (?i) at the beginning of the striong will make the comparison case insensitive
+Adding (?i) at the beginning of the string will make the comparison case insensitive
 
 ```
 SELECT * FROM cypher('graph_name', $$


### PR DESCRIPTION
Column as the result of rand() Numeric Function renaming that to more
meaningful name "random".

![image](https://user-images.githubusercontent.com/63642648/213777845-29244817-23b1-45c6-8b2d-6e03599e8498.png)
