### PR TITLE
Agtype NULL vs Postgres NULL

### DIFF
--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -48,7 +48,7 @@ Result:
 
 #### Agtype NULL vs Postgres NULL
 
-The concept is same for Agtype NULL and Postgres NULL as it is for Cypher.
+The concept of NULL in Agtype and Postgres is same as it is in Cypher.
 
 ### Integer
 

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -48,6 +48,7 @@ Result:
 
 #### Agtype NULL vs Postgres NULL
 
+The concept is same for Agtype NULL and Postgres NULL as it is for Cypher.
 
 ### Integer
 

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -48,7 +48,7 @@ Result:
 
 #### Agtype NULL vs Postgres NULL
 
-The concept of NULL in Agtype and Postgres is same as it is in Cypher.
+The concept of NULL in Agtype and Postgres is the same as it is in Cypher.
 
 ### Integer
 


### PR DESCRIPTION
There was no detail given below the heading 'Agtype NULL vs Postgres NULL' heading.  I updated it.