### PR TITLE
Fixed Typos and Punctuation

### DIFF
--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -37,15 +37,15 @@ sudo apt-get install build-essential libreadline-dev zlib1g-dev flex bison
 
 ### Install Postgres
 
-You will need to install a AGE compatible version of Postgres, for now AGE only supports Postgres 11 and 12.
+You will need to install a AGE-compatible version of Postgres. For now, AGE only supports Postgres 11 and 12.
 
 #### Install From Source Code
 
-You can <a href='https://www.postgresql.org/download/'>download the Postgres source code</a> and install your own instance of Postgres. You can read instructions on how to install from <a href='https://www.postgresql.org/docs/11/installation.html'>source code on the offical Postgres Website</a>
+You can <a href='https://www.postgresql.org/download/'>download the Postgres source code</a> and install your own instance of Postgres. You can read instructions on how to install from <a href='https://www.postgresql.org/docs/11/installation.html'>source code on the offical Postgres Website</a>.
 
 #### Install From a Package Manager
 
-You can use a package management that your OS provides to download AGE.
+You can use the package manager that your OS provides to download AGE.
 
 #### Ubuntu
 
@@ -64,7 +64,7 @@ sudo apt install postgresql-12
 
 Clone the <a href='https://github.com/apache/age'>github repository</a> or <a href='https://github.com/apache/age/releases'>download an official release</a>
 
-Run the pg_config utility and check the version of PostgreSQL, currently only PostgreSQL versions 11 & 12 are supported. If you have any other version of postgres, you will need to install PostgreSQL version 11 & 12. Follow Setting up multiple versions of PostgreSQL
+Run the pg_config utility and check the version of PostgreSQL, currently only PostgreSQL versions 11 and 12 are supported. If you have any other version of postgres, you will need to install PostgreSQL version 11 or 12. Follow Setting up multiple versions of PostgreSQL
 ```console
 pg_config
 ```


### PR DESCRIPTION
line 40:  - "AGE compatible" to AGE-compatible
	     - replaced comma with a period, which in my opinion increases readability. 

line 44:  - added a period at the end

line 48: - Fixed a typo:
		Original: "You can use a package management that your OS provides to download AGE."
		Fixed: "You can use the package manager that your OS provides to download AGE."

line 67: - replaced '&' with 'and' to ensure consistency with the rest of the document.
	    - replaced an '&' with an 'or' because it was a typo