### PR TITLE
Updated docs/intro/comparability.md Fixed the ambiguous position of 'Edge' in the order

### DIFF
--- a/docs/intro/comparability.md
+++ b/docs/intro/comparability.md
@@ -102,16 +102,15 @@ p1 < p2
 
 The ordering of different Agtype, when using &lt;, &lt;=, >, >= from smallest value to largest value is: 
 
-1. Edge
-2. Path
-3. Map
-4. Vertex
-5. Edge
-6. Array
-7. String
-8. Bool
-9. Numeric, Integer, Float
-10. NULL
+1. Path
+2. Edge
+3. Vertex
+4. Object
+5. Array
+6. String
+7. Bool
+8. Numeric, Integer, Float
+9. NULL
 
 Note: This is subject to change in future releases.
 


### PR DESCRIPTION
In relation to this issue: -
https://github.com/apache/age-website/issues/143

The position of Edge has been fixed and multiple occurrences have been removed.

Insights taken from this stackoverflow question
https://stackoverflow.com/questions/75845310/clarification-regarding-apache-age-documentation-orderability-between-different/75845824#75845824

And this file in code
https://github.com/apache/age/blob/master/src/backend/utils/adt/agtype_util.c