### PR TITLE
Updated readme.md -- Removed errors from cypher queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 * Install requirements (the latex and dvisvgm commands are required to display math)
 
+- **MacOS**
+```shell
+brew install python3 virtualenv texlive
+```
+
+- **Ubuntu**
 ```shell
 sudo apt install python3 virtualenv texlive-latex-base texlive-latex-extra texlive-extra-utils
 ```

--- a/docs/functions/aggregate_functions.md
+++ b/docs/functions/aggregate_functions.md
@@ -87,7 +87,7 @@ Result:
    </td>
   </tr>
   <tr>
-   <td>2123e1af756543542064ae0d07792be90176b311be
+   <td>13
    </td>
   </tr>
   <tr>
@@ -352,7 +352,7 @@ SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
     RETURN stDevP(n.age)
-$$ as (stdevp_age agtype);
+$$) as (stdevp_age agtype);
 ```
 
 
@@ -432,7 +432,7 @@ SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
     RETURN percentileCont(n.age, 0.4)
-$$ as (percentile_cont_age agtype);
+$$) as (percentile_cont_age agtype);
 ```
 
 
@@ -512,7 +512,7 @@ SELECT *
 FROM cypher('graph_name', $$
     MATCH (n:Person)
     RETURN percentileDisc(n.age, 0.5)
-$$ as (percentile_disc_age agtype);
+$$) as (percentile_disc_age agtype);
 ```
 
 
@@ -590,7 +590,7 @@ SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})-[]->(x)
     RETURN n.age, count(*)
-$$ as (age agtype, number_of_people agtype);
+$$) as (age agtype, number_of_people agtype);
 ```
 
 The labels and age property of the start node n and the number of nodes related to n are returned.
@@ -624,7 +624,7 @@ SELECT *
 FROM cypher('graph_name', $$
     MATCH (n {name: 'A'})-[r]->()
     RETURN type(r), count(*)
-$$ as (label agtype, count agtype);
+$$) as (label agtype, count agtype);
 ```
 
 
@@ -890,7 +890,7 @@ SELECT *
 FROM cypher('graph_name', $$
 MATCH (n:Person)
 RETURN sum(n.age)
-$$ as (total_age agtype);
+$$) as (total_age agtype);
 ```
 
 

--- a/docs/functions/logarithmic_functions.md
+++ b/docs/functions/logarithmic_functions.md
@@ -136,7 +136,7 @@ Query:
 ```postgresql
 SELECT *
 FROM cypher('graph_name', $$
-    RETURN e(2)
+    RETURN exp(2)
 $$) as (e agtype);
 ```
 
@@ -282,8 +282,8 @@ Query:
 ```postgresql
 SELECT *
 FROM cypher('graph_name', $$
-    RETURN log(27)
-$$) as (natural_logarithm agtype);
+    RETURN log10(27)
+$$) as (common_logarithm agtype);
 ```
 
 
@@ -294,7 +294,7 @@ Result:
 
 <table>
   <tr>
-   <td>natural_logarithm
+   <td>common_logarithm
    </td>
   </tr>
   <tr>

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -309,7 +309,7 @@ Query:
 ```postgresql
 SELECT *
 FROM cypher('graph_name', $$
-    RETURN cosin(0.5)
+    RETURN cos(0.5)
 $$) as (c agtype);
 ```
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -37,7 +37,7 @@ Function `load_edges_from_file` can be used to load properties from the CSV file
 Note: make sure that ids in the edge file are identical to ones that are in vertices files. 
 
 ```postgresql
-oad_edges_from_file('<graph name>',
+load_edges_from_file('<graph name>',
                     '<label name>',
                     '<file path>');
 ```
@@ -80,7 +80,7 @@ SELECT create_graph('agload_test_graph');
 SELECT create_vlabel('agload_test_graph','Country');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country',
-                             'age_load/countries.csv');
+                             'age_load/data/countries.csv');
 ```
 
 - Create label `City` and load vertices from csv file. *** Note this CSV file has id field ***
@@ -89,7 +89,7 @@ SELECT load_labels_from_file('agload_test_graph',
 SELECT create_vlabel('agload_test_graph','City');
 SELECT load_labels_from_file('agload_test_graph',
                              'City', 
-                             'age_load/cities.csv');
+                             'age_load/data/cities.csv');
 ```
 
 - Create label `has_city` and load edges from csv file.
@@ -97,7 +97,7 @@ SELECT load_labels_from_file('agload_test_graph',
 ```postgresql
 SELECT create_elabel('agload_test_graph','has_city');
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
-     'age_load/edges.csv');
+     'age_load/data/edges.csv');
 ```
 
 - check if the graph has been loaded properly
@@ -123,7 +123,7 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
 SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country2',
-                             'age_load/countries.csv', 
+                             'age_load/data/countries.csv', 
                              false);
 ```
 
@@ -132,7 +132,7 @@ SELECT load_labels_from_file('agload_test_graph',
 SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph',
                              'City2',
-                             'age_load/cities.csv', 
+                             'age_load/data/cities.csv', 
                              false);
 ```
 - check if the graph has been loaded properly and perform difference analysis between ids created automatically and picked from the files.

--- a/docs/intro/operators.md
+++ b/docs/intro/operators.md
@@ -114,7 +114,7 @@ AGE supports the use of [POSIX regular expressions](https://www.postgresql.org/d
 
 #### Basic String Matching
 
-The =~ operator when no special characters are give, act like the = operator.
+The =~ operator when no special characters are given, act like the = operator.
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$


### PR DESCRIPTION
## Summary
This pull request removes syntax errors in cypher queries in the documentation. Also updated readme.md file to include command for building the documentation in macOS as referred in issue #142 

## Changes Made
- Updated readme.md file to address issue #142 
-  Fixed syntax error in cypher query in **agload.md** 
- Updated sample data file path in **agload.md**
- Fixed incorrect function call  of *exp* in **logarithmic_functions.md**
-  Fixed function call of *log10* in **logarithmic_functions.md**
- Fixed incorrect function call  of *cos* in **trigonometric_functions.md**
- Fixed output on *min()* cypher query in **aggregate_functions.md**
- Added missing bracket in cypher queries of functions like *stDevP(), percentileCont(), percentileDisc(), Count(), SUM()* in **aggregate_functions.md**


