### PR TITLE
Fixed example query typo in predicate_functions.md

### DIFF
--- a/docs/functions/predicate_functions.md
+++ b/docs/functions/predicate_functions.md
@@ -82,7 +82,7 @@ EXISTS(path) returns true if for the given path, there already exists the given 
 SELECT *
 FROM cypher('graph_name', $$
      MATCH (n)
-     WHERE exists(n)-[]-(name: 'Willem Defoe')
+     WHERE exists((n)-[]-({name: 'Willem Defoe'}))
      RETURN n.full_name
 $$) as (full_name agtype);
 ```


### PR DESCRIPTION
Fixed typo pointed out in GitHub [issue](https://github.com/apache/age/issues/950#issue-1728449994) raised in the AGE repository. 