### PR TITLE
[age-website] Corrected typo in Directed Edges and Variable example in match.md

### DIFF
--- a/docs/clauses/match.md
+++ b/docs/clauses/match.md
@@ -228,7 +228,7 @@ Query
 SELECT * FROM cypher('graph_name', $$
 MATCH (:Person {name: 'Oliver Stone'})-[r]->(movie)
 RETURN type(r)
-$$) as (type agtype);
+$$) as (title agtype);
 ```
 
 


### PR DESCRIPTION
Fixed the typo in the documentation under `MATCH`, the column header is defined as 'type' instead of 'title' in the return column list as seen [here](https://age.apache.org/age-manual/master/clauses/match.html#directed-edges-and-variable).