### PR TITLE
Updated docs/clauses/create.md; fixed syntax error

### DIFF
--- a/docs/clauses/create.md
+++ b/docs/clauses/create.md
@@ -135,7 +135,7 @@ Query
 ```postgresql
 SELECT * 
 FROM cypher('graph_name', $$
-    CREATE (:Person {name: 'Andres', title: 'Developer')
+    CREATE (:Person {name: 'Andres', title: 'Developer'})
 $$) as (n agtype);
 ```
 


### PR DESCRIPTION
Fixed the syntax error mentioned under issue #117.  I have updated the documentation under `CREATE`. 