### PR TITLE
Move "Explanation about the CSV format" to document start for better clarity

### DIFF
--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -7,10 +7,33 @@ You can use the following instructions to create a graph from the files. This do
 
 
 User can load graph in two steps 
+- Create graph and labels before loading data from files
 - Load Vertices in the first step
 - Load Edges in the second step
 
-**User must create graph and labels before loading data from files**
+
+## Explanation about the CSV format
+Following is the explanation about the structure for CSV files for vertices and edges.
+
+- A CSV file for nodes shall be formatted as following; 
+
+| field name | Field description                                            |
+| ---------- | ------------------------------------------------------------ |
+| id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
+| Properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
+
+- Similarly, a CSV file for edges shall be formatted as follows:
+
+| field name        | Field description                                            |
+| ----------------- | ------------------------------------------------------------ |
+| start_id          | node id of the node from where the edge is stated. This id shall be present in nodes.csv file. |
+| start_vertex_type | class of the node                                            |
+| end_id            | end id of the node at which the edge shall be terminated    |
+| end_vertex_type   | Class of the node                                            |
+| properties        | properties of the edge. the header shall contain the property name |
+
+Example files can be viewed at `regress/age_load/data`
+
 
 ## Load Graph functions 
 Following are the details about the functions to create vertices and edges from the file. 
@@ -42,27 +65,6 @@ load_edges_from_file('<graph name>',
                     '<file path>');
 ```
 
-## Explanation about the CSV format
-Following is the explanation about the structure for CSV files for vertices and edges.
-
-- A CSV file for nodes shall be formatted as following; 
-
-| field name | Field description                                            |
-| ---------- | ------------------------------------------------------------ |
-| id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| Properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
-
-- Similarly, a CSV file for edges shall be formatted as follows 
-
-| field name        | Field description                                            |
-| ----------------- | ------------------------------------------------------------ |
-| start_id          | node id of the node from where the edge is stated. This id shall be present in nodes.csv file. |
-| start_vertex_type | class of the node                                            |
-| end_id            | end id of the node at which the edge shall be terminated    |
-| end_vertex_type   | Class of the node                                            |
-| properties        | properties of the edge. the header shall contain the property name |
-
-example files can be viewed at `regress/age_load/data`
 
 ## Example SQL script 
 


### PR DESCRIPTION
As the structure of the CSV files required is unique to Apache AGE, it would be beneficial to move the section to the beginning of the document. This way, users will know upfront the structure their data needs to be in, and they can prepare their CSV files accordingly before they begin working with the functions.