### PR TITLE
In-line code formatting for the Introduction section

### DIFF
--- a/docs/clauses/delete.md
+++ b/docs/clauses/delete.md
@@ -14,9 +14,9 @@ For removing properties, see REMOVE.
 You cannot delete a node without also deleting edges that start or end on said vertex. Either explicitly delete the vertices,or use DETACH DELETE.
 
 
-## Delete single vertex
+## Delete isolated vertices
 
-To delete a vertex, use the DELETE clause.
+To delete vertices with no edges associated with them, use the DELETE clause only.
 
 Query
 
@@ -30,7 +30,7 @@ $$) as (v agtype);
 ```
 
 
-Nothing is returned from this query.
+This will delete the vertices (with label Useless) that have no edges. Nothing is returned from this query.
 
 
 <table>
@@ -44,9 +44,9 @@ Nothing is returned from this query.
   </tr>
 </table>
 
-## Delete all vertices and edges
+## Delete all vertices and edges associated with them
 
-Running a Match clause will collect all nodes, use the DETACH option to first delete a vertice's edges then delete the vertex itself.
+To delete all vertices (with label Useless) and the edges associated with them, use the DETACH option to first delete the vertice's edges then delete the vertex itself.
 
 Query
 

--- a/docs/clauses/match.md
+++ b/docs/clauses/match.md
@@ -111,7 +111,7 @@ Returns all the movies in the database.
 
 ### Related Vertices
 
-The symbol -[]- means related to, without regard to type or direction of the edge.
+The symbol `-[]-` means related to, without regard to type or direction of the edge.
 
 Query
 
@@ -184,7 +184,7 @@ Returns any vertices connected with the Person 'Oliver' that are labeled Movie.
 
 ### Outgoing Edges
 
-When the direction of an edge is of interest, it is shown by using -> or &lt;-.
+When the direction of an edge is of interest, it is shown by using `->` or &lt;-.
 
 Query
 
@@ -340,7 +340,7 @@ Returns ACTED_IN roles for 'Wall Street'.
 
 ### Multiple Edges
 
-Edges can be expressed by using multiple statements in the form of ()-[]-(), or they can be strung together.
+Edges can be expressed by using multiple statements in the form of `()-[]-()`, or they can be strung together.
 
 Query
 

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -101,7 +101,7 @@ RETURN michael.name, michael.bornIn
 $$) as (Name agtype, BornIn agtype);
 ```
 
-'Michael Douglas' will match the existing vertex and the vertex's name and bornIn properties returned.
+'Michael Douglas' will match the existing vertex and the vertex's name and BornIn properties are returned.
 
 <table>
   <tr>

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -37,7 +37,7 @@ RETURN v
 $$) as (v agtype);
 ```
 
-If there exists a vertex with the label 'Critic' the vertex will be returns. If the vertex will be created and returned.
+If there exists a vertex with the label 'Critic' the vertex will be returns. Otherwise, the vertex will be created and returned.
 
 <table>
   <tr>
@@ -68,7 +68,7 @@ RETURN charlie
 $$) as (v agtype);
 ```
 
-If there exists a vertex with the label 'Critic' the vertex will be returns. If the vertex will be created and returned.
+If there exists a vertex with the label 'Critic' the vertex will be returns. Otherwise the vertex will be created and returned.
 
 <table>
   <tr>
@@ -85,7 +85,7 @@ If there exists a vertex with the label 'Critic' the vertex will be returns. If 
   </tr>
 </table>
 
-A new vertex with the name 'Charlie Sheen' will be created if not all properties exist with a single vertex. If a vertex does exist that will be returned instead.
+If a vertex with all the properties exist that will be returned. Otherwise, a new vertex with the name 'Charlie Sheen' will be created and returned.
 
 
 ### Merge a Single Vertex Specifying Both Label and Property

--- a/docs/functions/map_functions.md
+++ b/docs/functions/map_functions.md
@@ -1,0 +1,61 @@
+# Map Functions
+
+In AGE, a map is a data structure that allows you to store a collection of key-value pairs. Each key within a map is unique, and it is associated with a corresponding value. 
+This data structure is similar to dictionaries in Python or objects in JavaScript, providing an efficient way to organize and retrieve data based on keys.
+This section focuses on explaining various functions that allow you to generate and manipulate maps effectively.
+
+## vertex_stats()
+The `vertex_stats()` function can extract information from a vertex. Upon passing a vertex as an argument to the vertex_stats function, 
+you are presented with a structured map, which includes the following key-value pairs:
+
+* id: A unique identifier assigned to the vertex;
+* label: The label or type that categorizes the vertex;
+* in_degree: The count of incoming edges directed towards the vertex;
+* out_degree: The count of outgoing edges originating from the vertex;
+* self_loops: The count of self-loop edges associated with the vertex.
+
+Syntax: `vertex_stats(vertex)`
+
+### Setup
+
+```sql
+-- Creating the graph.
+SELECT create_graph('vertex_stats_graph');
+
+-- Creating vertices and edges.
+SELECT * FROM cypher('vertex_stats_graph', $$
+CREATE (:Person {name: 'John Donne'})-[:WROTE]->(:Poem {title: 'Holy Sonnet XIV'})
+$$) AS (a agtype);
+```
+
+### Query
+
+```sql
+SELECT * FROM cypher('vertex_stats_graph', $$
+MATCH (v:Poem {title: 'Holy Sonnet XIV'})
+RETURN vertex_stats(v)
+$$) AS (vertex_stats agtype);
+```
+
+### Result
+
+<table>
+  <tr>
+   <td>vertex_stats
+   </td>
+  </tr>
+  <tr>
+   <td>{"id": 1407374883553281, "label": "Poem", "in_degree": 1, "out_degree": 0, "self_loops": 0}
+   </td>
+  </tr>
+  <tr>
+   <td>(1 row)
+   </td>
+  </tr>
+</table>
+
+### Retrieving Values
+
+It is also possible to retrieve specific values from the generated map using the following syntax: 
+
+`vertex_stats(vertex)["key"]`

--- a/docs/functions/numeric_functions.md
+++ b/docs/functions/numeric_functions.md
@@ -358,7 +358,11 @@ Syntax:sign(expression)
 
 Returns:
 
-An Integer.
+```
+An integer.
+```
+
+
 
 Arguments:
 

--- a/docs/functions/string_functions.md
+++ b/docs/functions/string_functions.md
@@ -496,7 +496,7 @@ Returns:
 
 
 ```
-A String.
+An agtype String.
 ```
 
 

--- a/docs/functions/string_functions.md
+++ b/docs/functions/string_functions.md
@@ -462,7 +462,7 @@ Query:
 SELECT *
 FROM cypher('graph_name', $$
     RETURN rTrim(' hello ')
-$$) as (trimmed_str agtype);
+$$) as (right_trimmed_str agtype);
 ```
 
 
@@ -471,7 +471,7 @@ Result:
 
 <table>
   <tr>
-   <td>trimmed_str
+   <td>right_trimmed_str
    </td>
   </tr>
   <tr>
@@ -488,7 +488,7 @@ Result:
 
 ## lTrim
 
-lTrim() returns the original string with trailing whitespace removed.
+lTrim() returns the original string with leading whitespace removed.
 
 Syntax: `lTrim(original)`
 
@@ -532,7 +532,7 @@ Query:
 SELECT *
 FROM cypher('graph_name', $$
     RETURN lTrim(' hello ')
-$$) as (trimmed_str agtype);
+$$) as (left_trimmed_str agtype);
 ```
 
 
@@ -698,7 +698,7 @@ Result:
 
 ## toUpper
 
-toUpper() returns the original string in lowercase.
+toUpper() returns the original string in uppercase.
 
 Syntax: `toUpper(original)`
 
@@ -812,7 +812,7 @@ Query:
 SELECT *
 FROM cypher('graph_name', $$
     RETURN reverse("hello")
-$$) as (upper_str agtype);
+$$) as (reverse_str agtype);
 ```
 
 
@@ -821,7 +821,7 @@ Result:
 
 <table>
   <tr>
-   <td>upper_str
+   <td>reverse_str
    </td>
   </tr>
   <tr>
@@ -840,7 +840,7 @@ Result:
 
 toString() converts an integer, float or boolean value to a string.
 
-Syntax:`toString(expression)`
+Syntax: `toString(expression)`
 
 Returns:
 

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -11,7 +11,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -75,7 +75,7 @@ Results:
 
 ## radians
 
-radians() converts radians to degrees.
+radians() converts degrees to radians.
 
 Syntax:`radians(expression)`
 
@@ -83,7 +83,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -177,7 +177,7 @@ Result:
 
 <table>
   <tr>
-   <td>p
+   <td>pi
    </td>
   </tr>
   <tr>
@@ -202,7 +202,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -274,7 +274,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -346,7 +346,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -418,7 +418,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -455,7 +455,7 @@ Query:
 SELECT *
 FROM cypher('graph_name', $$
     RETURN asin(0.5)
-$$) as (s agtype);
+$$) as (arc_s agtype);
 ```
 
 
@@ -466,7 +466,7 @@ Results:
 
 <table>
   <tr>
-   <td>s
+   <td>arc_s
    </td>
   </tr>
   <tr>
@@ -491,7 +491,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -564,7 +564,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 
@@ -604,7 +604,7 @@ $$) as (arc_t agtype);
 ```
 
 
-The arccosine of 0.5 is returned.
+The arctangent of 0.5 is returned.
 
 Results:
 
@@ -636,7 +636,7 @@ Returns:
 
 
 ```
-A Float.
+An agtype Float.
 ```
 
 

--- a/docs/intro/aggregation.md
+++ b/docs/intro/aggregation.md
@@ -3,9 +3,9 @@
 
 ## Introduction 
 
-Generally an aggregation aggr(expr) processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.md)).
+Generally an aggregation, `aggr(expr)`, processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.md)).
 
-In a regular aggregation (i.e. of the form aggr(expr)), the list of aggregated values is the list of candidate values with all null values removed from it.
+In a regular aggregation (i.e. of the form `aggr(expr)`), the list of aggregated values is the list of candidate values with all null values removed from it.
 
 ## Data Setup
 
@@ -25,11 +25,11 @@ $$) as (a agtype);
 ```
 
 ## Auto Group By
-To calculate aggregated data, Cypher offers aggregation, analogous to SQL’s GROUP BY.
+To calculate aggregated data, Cypher offers aggregation, analogous to SQL’s `GROUP BY`.
 
-Aggregating functions take a  set of values and calculate An aggregated value over them. Examples are [avg()](../functions/aggregate_functions.md#avg) that calculates the average of multiple numeric values, or [min()](../functions/aggregate_functions.md#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression(such as n.age) to all the records within the same aggregation group.
+Aggregating functions take a  set of values and calculates an aggregated value over them. Examples are [`avg()`](../functions/aggregate_functions.md#avg) that calculates the average of multiple numeric values, or [`min()`](../functions/aggregate_functions.md#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression (such as `n.age`) to all the records within the same aggregation group.
 
-Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the valuesgoing into the aggregate functions.
+Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the values going into the aggregate functions.
 
 Assume we have the following return statement:
 ```postgresql
@@ -41,8 +41,8 @@ $$) as (grouping_key agtype, count agtype);
 
 <table>
   <tr>
+   <td>grouping_key</td>
    <td>count</td>
-   <td>key</td>
   </tr>
   <tr>
    <td>"A"</td>
@@ -61,16 +61,16 @@ $$) as (grouping_key agtype, count agtype);
    <td>2</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(4 rows)</td>
   </tr>
 </table>
 
 
-We have two return expressions: grouping_key, and count(*). The first, grouping_key, is not an aggregate function, and so it will  be  the  grouping  key. The latter, count(*) is an aggregate expression. The matching subgraphs will be divided into different  buckets, depending on the grouping key. The aggregate function will then be run on these buckets, calculating an aggregate value per bucket. 
+We have two return expressions: `grouping_key`, and `count(*)`. The first, `grouping_key`, is not an aggregate function, and so it will  be  the  grouping  key. The latter, `count(*)` is an aggregate expression. The matching subgraphs will be divided into different  buckets, depending on the grouping key. The aggregate function will then be run on these buckets, calculating an aggregate value per bucket. 
 
 ## Sorting on aggregate functions
 
-To use aggregations to sort the result set, the aggregation must be included in the RETURN to be used in the ORDER BY.
+To use aggregations to sort the result set, the aggregation must be included in the `RETURN` to be used in the `ORDER BY`.
 
 ```postgresql
 SELECT *
@@ -82,10 +82,10 @@ $$) as (friends agtype, me agtype);
 ```
 
 ## Distinct aggregation
-In a distinct aggregation (i.e. of the form aggr(DISTINCT expr)), the list of aggregated values is the list of candidate values with all null values  removed from it. Furthermore, in a distinct aggregation, only one of all equivalent candidate values is included in the list of aggregated values, i.e. duplicates under equivalence are  removed. 
+In a distinct aggregation (i.e. of the form `aggr(DISTINCT expr)`), the list of aggregated values is the list of candidate values with all null values  removed from it. Furthermore, in a distinct aggregation, only one of all equivalent candidate values is included in the list of aggregated values, i.e. duplicates under equivalence are  removed. 
 
 
-The DISTINCT operator works in conjunction with aggregation. It is used to make all values unique before running them  through an aggregate function.
+The `DISTINCT` operator works in conjunction with aggregation. It is used to make all values unique before running them  through an aggregate function.
 
 ```postgresql
 SELECT *
@@ -105,7 +105,7 @@ $$) as (distinct_eyes agtype, eyes agtype);
    <td>3</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(1 row)</td>
   </tr>
 </table>
 
@@ -123,7 +123,7 @@ $$) as (a agtype);
 ```
 
 ### Invalid Query in AGE
-AGE's solution to this problem is to not allow a WITH or RETURN column to combine aggregate functions with variables that are not explicitly listed in another column of the same WITH or RETURN clause.
+AGE's solution to this problem is to not allow a `WITH` or `RETURN` column to combine aggregate functions with variables that are not explicitly listed in another column of the same `WITH` or `RETURN` clause.
 
 
 
@@ -143,7 +143,7 @@ LINE 3: RETURN x.a + count(*) + x.b + count(*) + x.c
 
 
 ### Valid Query in AGE
-Columns that do not include an aggregate function in AGE are considered to be the grouping keys for that WITH or RETURN clause. 
+Columns that do not include an aggregate function in AGE are considered to be the grouping keys for that `WITH` or `RETURN` clause. 
 
 For the above query, the user could rewrite the query is several ways that will return results
 
@@ -155,7 +155,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, key agtype);
 ```
 
-x.a + x.b + x.c is the grouping key. Grouping keys created like this must include parenthesis.
+`x.a + x.b + x.c` is the grouping key. Grouping keys created like this must include parenthesis.
 
 Results
 <table>
@@ -168,7 +168,7 @@ Results
    <td>6</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(1 row)</td>
   </tr>
 </table>
 
@@ -182,7 +182,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, a agtype, b agtype, c agtype);
 ```
 
-x.a, x.b, and x.c will be considered different grouping keys
+`x.a`, `x.b`, and `x.c` will be considered different grouping keys
 
 Results:
 
@@ -214,13 +214,13 @@ Results:
    <td>3</td>
   </tr>
   <tr>
-   <td colspan="4">3 rows</td>
+   <td colspan="4">(3 rows)</td>
   </tr>
 </table>
 
 ### Vertices and edges in ambiguous grouping
 
-Alternatively, the grouping key can be a vertex or edge, and then any properties of the vertex or edge can be specified without being explicitly stated in a WITH or RETURN column.
+Alternatively, the grouping key can be a vertex or edge, and then any properties of the vertex or edge can be specified without being explicitly stated in a `WITH` or `RETURN` column.
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
@@ -229,7 +229,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, key agtype);
 ```
 
-Results will be grouped on x, because it is safe to assume that properties be considered unecessary for grouping to be unambiguous.
+Results will be grouped on `x`, because it is safe to assume that properties be considered unecessary for grouping to be unambiguous.
 
 Results
 <table>
@@ -252,14 +252,14 @@ Results
    <td>{"id": 1407374883553282, "label": "L", "properties": {"a": 2, "b": 3, "c": 1}}::vertex</td>
   </tr>
   <tr>
-   <td colspan="4">3 rows</td>
+   <td colspan="4">(3 rows)</td>
   </tr>
 </table>
 
 
 ### Hiding unwanted grouping keys
 
-If the grouping key is considered unecessary for the query output, the aggregation can be done in a WITH clause then passing information to the RETURN clause.
+If the grouping key is considered unecessary for the query output, the aggregation can be done in a `WITH` clause then passing information to the `RETURN` clause.
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
@@ -286,7 +286,7 @@ Results
    <td>8</td>
   </tr>
   <tr>
-   <td colspan="1">3 rows</td>
+   <td colspan="1">(3 rows)</td>
   </tr>
 </table>
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -50,8 +50,8 @@ Following is the explanation about the structure for CSV files for vertices and 
 
 | field name | Field description                                            |
 | ---------- | ------------------------------------------------------------ |
-| id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
+| id         | it shall be the first column of the file and all values shall be a positive integer. <br>This is an optional field when `id_field_exists` is ***false***. <br>However, it should be present when `id_field_exists` is ***not*** set to false.  |
+| Properties | all other columns contains the properties for the nodes. <br>Header row shall contain the name of property |
 
 - Similarly, a CSV file for edges shall be formatted as follows 
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -49,14 +49,14 @@ Following is the explanation about the structure for CSV files for vertices and 
 
 | field name | Field description                                            |
 | ---------- | ------------------------------------------------------------ |
-| id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
+| id         | it shall be the first column of the file and all values shall be a positive integer. <br>This is an optional field when `id_field_exists` is ***false***. <br>However, it should be present when `id_field_exists` is ***not*** set to false.  |
+| Properties | all other columns contains the properties for the nodes. <br>Header row shall contain the name of property |
 
 - Similarly, a CSV file for edges shall be formatted as follows 
 
 | field name        | Field description                                            |
 | ----------------- | ------------------------------------------------------------ |
-| start_id          | node id of the node from where the edge is stated. This id shall be present in nodes.csv file. |
+| start_id          | node id of the node from where the edge is stated. <br>This id shall be present in nodes.csv file. |
 | start_vertex_type | class of the node                                            |
 | end_id            | end id of the node at which the edge shall be terminated    |
 | end_vertex_type   | Class of the node                                            |

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -3,10 +3,10 @@ You can use the following instructions to create a graph from the files. This do
 - information about the current branch that includes the functions to load graphs from files
 - explanation of the functions that enable the creation of graphs from files 
 - the structure of CSV files that load functions as input, do and do not. 
-- A simple source code example to load countries and cities from the files. 
+- a simple source code example to load countries and cities from the files. 
 
 
-User can load graph in two steps 
+User can load a graph in two steps 
 - Load Vertices in the first step
 - Load Edges in the second step
 
@@ -15,7 +15,7 @@ User can load graph in two steps
 ## Load Graph functions 
 Following are the details about the functions to create vertices and edges from the file. 
 
-function `load_labels_from_file` is used to load vertices from the CSV files. 
+Function `load_labels_from_file` is used to load vertices from the CSV files. 
 
 ```postgresql
 load_labels_from_file('<graph name>', 
@@ -23,7 +23,7 @@ load_labels_from_file('<graph name>',
                       '<file path>')
 ```
 
-By adding the fourth parameter user can exclude the id field. *** Use this when there is no id field in the file***
+By adding the fourth parameter user can exclude the id field. ***Use this when there is no id field in the file.***
 
 ```postgresql
 load_labels_from_file('<graph name>', 
@@ -50,7 +50,7 @@ Following is the explanation about the structure for CSV files for vertices and 
 | field name | Field description                                            |
 | ---------- | ------------------------------------------------------------ |
 | id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| Properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
+| properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
 
 - Similarly, a CSV file for edges shall be formatted as follows 
 
@@ -62,11 +62,11 @@ Following is the explanation about the structure for CSV files for vertices and 
 | end_vertex_type   | Class of the node                                            |
 | properties        | properties of the edge. the header shall contain the property name |
 
-example files can be viewed at `regress/age_load/data`
+Example files can be viewed at `regress/age_load/data`.
 
 ## Example SQL script 
 
-- Load and create graph 
+- Load and create graph.
 ```postgresql
 LOAD 'age';
 
@@ -74,7 +74,7 @@ SET search_path TO ag_catalog;
 SELECT create_graph('agload_test_graph');
 ```
 
-- Create label `Country` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `Country` and load vertices from csv file. ***Note this CSV file has id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','Country');
@@ -83,7 +83,7 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/countries.csv');
 ```
 
-- Create label `City` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `City` and load vertices from csv file. ***Note this CSV file has id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','City');
@@ -92,7 +92,7 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/cities.csv');
 ```
 
-- Create label `has_city` and load edges from csv file.
+- Create label `has_city` and load edges from CSV file.
 
 ```postgresql
 SELECT create_elabel('agload_test_graph','has_city');
@@ -100,7 +100,7 @@ SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/data/edges.csv');
 ```
 
-- check if the graph has been loaded properly
+- Check if the graph has been loaded properly.
 
 ```postgresql
 SELECT table_catalog, table_schema, table_name, table_type
@@ -117,7 +117,7 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
 
 ### Creating vertices without id field in the file. 
 
-- Create label `Country2` and load vertices from csv file. *** Note this CSV file has no id field ***
+- Create label `Country2` and load vertices from CSV file. ***Note this CSV file has no id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','Country2');
@@ -127,7 +127,8 @@ SELECT load_labels_from_file('agload_test_graph',
                              false);
 ```
 
-- Create label `City2` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `City2` and load vertices from CSV file. ***Note this CSV file has id field.***
+
 ```postgresql
 SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph',
@@ -135,10 +136,12 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/cities.csv', 
                              false);
 ```
-- check if the graph has been loaded properly and perform difference analysis between ids created automatically and picked from the files.
 
-- labels `Country` and `City` were created with id field in the file
-- labels `Country2` and `City2` were created with no id field in the file. 
+- Check if the graph has been loaded properly and perform difference analysis between ids created automatically and picked from the files.
+
+- Labels `Country` and `City` were created with id field in the file.
+- Labels `Country2` and `City2` were created with no id field in the file.
+
 ```postgresql
 SELECT COUNT(*) FROM agload_test_graph."Country2";
 SELECT COUNT(*) FROM agload_test_graph."City2";

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -49,8 +49,8 @@ Following is the explanation about the structure for CSV files for vertices and 
 
 | field name | Field description                                            |
 | ---------- | ------------------------------------------------------------ |
-| id         | it shall be the first column of the file and all values shall be a positive integer. <br>This is an optional field when `id_field_exists` is ***false***. <br>However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| Properties | all other columns contains the properties for the nodes. <br>Header row shall contain the name of property |
+| id         | it shall be the first column of the file and all values shall be a positive integer. This is an optional field when `id_field_exists` is ***false***. However, it should be present when `id_field_exists` is ***not*** set to false.  |
+| properties | all other columns contains the properties for the nodes. Header row shall contain the name of property |
 
 - Similarly, a CSV file for edges shall be formatted as follows 
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -16,6 +16,7 @@ User can load a graph in two steps
 Following are the details about the functions to create vertices and edges from the file. 
 
 Function `load_labels_from_file` is used to load vertices from the CSV files. 
+Function `load_labels_from_file` is used to load vertices from the CSV files. 
 
 ```postgresql
 load_labels_from_file('<graph name>', 

--- a/docs/intro/comparability.md
+++ b/docs/intro/comparability.md
@@ -1,17 +1,17 @@
 # Comparability, Equality, Orderability and Equivalence
 
-AGE already has good semantics for equality within the primitive types (booleans, strings,integers, and floats) and maps. Furthermore, Cypher has good semantics for comparability and orderability for integers, floats, and strings, within each of the types. However, working with values of different types deviates from Postgres’ defined logic and the openCypher specification:
+AGE already has good semantics for equality within the primitive types (booleans, strings, integers, and floats) and maps. Furthermore, Cypher has good semantics for comparability and orderability for integers, floats, and strings, within each of the types. However, working with values of different types deviates from Postgres’ defined logic and the openCypher specification:
 
 
 
-* Comparability between values of different types is defined. This deviation is particularly pronounced when it occurs as part of the evaluation of predicates (in WHERE).
-* ORDER BY will not fail if the values passed to it have different types.
+* Comparability between values of different types is defined. This deviation is particularly pronounced when it occurs as part of the evaluation of predicates (in `WHERE`).
+* `ORDER BY` will not fail if the values passed to it have different types.
 
-The underlying conceptual model is complex and sometimes inconsistent. This leads to an unclear relationship between comparison operators, equality, grouping, and ORDER BY:
+The underlying conceptual model is complex and sometimes inconsistent. This leads to an unclear relationship between comparison operators, equality, grouping, and `ORDER BY`:
 * Comparability and orderability are aligned with each other consistently, as all types can be ordered and compared.
-* The difference between equality and equivalence, as exposed by IN, =, DISTINCT, and grouping, in AGE is limited to testing two instances of the value null to each other
-    * In equality, null = null is null.
-    * In equivalence, used by DISTINCT and when grouping values, two null values are always treated as being the same value.
+* The difference between equality and equivalence, as exposed by `IN`, `=`, `DISTINCT`, and grouping, in AGE is limited to testing two instances of the value `null` to each other.
+    * In equality, `null = null` is `null`.
+    * In equivalence, used by `DISTINCT` and when grouping values, two null values are always treated as being the same value.
     * However, equality treats null values differently if they are an element of a list or a map value.
 
 ## Concepts
@@ -31,12 +31,12 @@ Equality is used by the equality operators (=, &lt;>), and the list membership o
 
 ### Orderability
 
-Orderability is used by the ORDER BY clause, and defines the underlying semantics of how to order values.
+Orderability is used by the `ORDER BY` clause, and defines the underlying semantics of how to order values.
 
 
 ### Equivalence
 
-Equivalence is used by the DISTINCT modifier and by grouping in projection clauses (WITH,RETURN), and defines the underlying semantics to determine if two values are the same in these contexts.
+Equivalence is used by the `DISTINCT` modifier and by grouping in projection clauses (`WITH`, `RETURN`), and defines the underlying semantics to determine if two values are the same in these contexts.
 
 ## Comparability and equality
 
@@ -57,23 +57,23 @@ Comparability is defined between any pair of values, as specified below.
         * Integers are compared numerically in ascending order.
     * Floats
         * Floats (excluding NaN values and the Infinities) are compared numerically in ascending order.
-        * Positive infinity is of type FLOAT, equal to itself and greater than any other number, except NaN values.
-        * Negative infinity is of type FLOAT, equal to itself and less than any other number.
+        * Positive infinity is of type `FLOAT`, equal to itself and greater than any other number, except NaN values.
+        * Negative infinity is of type `FLOAT`, equal to itself and less than any other number.
         * NaN values are comparable to each and greater than any other float value.
     * Numeric
         * Numerics are compared numerically in ascending order.
 * Booleans
-    * Booleans are compared such that false is less than true.
+    * Booleans are compared such that `false` is less than `true`.
     * Comparison to any value that is not also a boolean follows the rules of orderability.
 * Strings
-    * Strings are compared in dictionary order, i.e. characters are compared pairwise in ascending order from the start of the string to the end. Characters missing in a shorter string are considered to be less than any other character. For example, 'a' &lt; 'aa'.
+    * Strings are compared in dictionary order, i.e. characters are compared pairwise in ascending order from the start of the string to the end. Characters missing in a shorter string are considered to be less than any other character. For example, `'a' < 'aa'`.
     * Comparison to any value that is not also a string follows the rules of orderability.
 * Lists
-    * Lists are compared in sequential order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including null values). For example, [1] &lt; [1, 0]but also [1] &lt; [1, null].
+    * Lists are compared in sequential order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including null values). For example, `[1] < [1, 0]`, but also `[1] < [1, null]`.
     * Comparison to any value that is not also a list follows the rules of orderability.
 * Maps
     * The comparison order for maps is unspecified and left to implementations.
-    * The comparison order for maps must align with the equality semantics outlined below. In consequence, any map that contains an entry that maps its key to a null value is incomparable. For example, {a: 1} &lt;= {a: 1, b: null} evaluates to null.
+    * The comparison order for maps must align with the equality semantics outlined below. In consequence, any map that contains an entry that maps its key to a null value is incomparable. For example, `{a: 1} <= {a: 1, b: null}` evaluates to `null`.
     * Comparison to any value that is not also a regular map follows the rules of orderability.
 
 Entities
@@ -82,7 +82,7 @@ Entities
 * Edges
     * The comparison order for edges is based on the assigned graphid.
 * Paths
-    * Paths are compared as if they were a list of alternating nodes and relationships of the path from the start node to the end node. For example, given nodes n1, n2, n3, and relationships r1and r2, and given that n1 &lt; n2 &lt; n3 and r1 &lt; r2, then the path p1 from n1 to n3 via r1 would be less than the path p2 to n1 from n2 via r2. 
+    * Paths are compared as if they were a list of alternating nodes and relationships of the path from the start node to the end node. For example, given nodes n1, n2, n3, and relationships r1 and r2, and given that n1 &lt; n2 &lt; n3 and r1 &lt; r2, then the path p1 from n1 to n3 via r1 would be less than the path p2 to n1 from n2 via r2. 
     * Expressed in terms of lists: 
 ```
 p1 < p2
@@ -95,7 +95,7 @@ p1 < p2
 ```
     * Comparison to any value that is not also a path will return false.
 * NULL
-    * null is incomparable with any other value (including other null values.)
+    * `null` is incomparable with any other value (including other null values.)
 
 
 ## Orderability Between different Agtypes

--- a/docs/intro/cypher.md
+++ b/docs/intro/cypher.md
@@ -1,6 +1,6 @@
 # The AGE Cypher Query Format
 
-Cypher queries are constructed using a function called cypher in ag_catalog which returns a Postgres SETOF [records](https://www.postgresql.org/docs/11/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET).
+Cypher queries are constructed using a function called cypher in `ag_catalog` which returns a Postgres `SETOF` [records](https://www.postgresql.org/docs/11/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET).
 
 
 ## Cypher()
@@ -68,7 +68,7 @@ Cypher may not be used as part of an expression, use a subquery instead. See [Ad
 
 ## SELECT Clause
 
-Calling Cypher in the SELECT clause as an independent column is not allowed. However Cypher may be used when it belongs as a conditional. 
+Calling Cypher in the `SELECT` clause as an independent column is not allowed. However Cypher may be used when it belongs as a conditional. 
 
 Not Allowed:
 

--- a/docs/intro/graphs.md
+++ b/docs/intro/graphs.md
@@ -5,7 +5,7 @@ A graph consists of a set of vertices and edges, where each individual node and 
 
 ## Create a Graph
 
-To create a graph, use the create_graph function, located in the ag_catalog namespace.
+To create a graph, use the `create_graph` function, located in the `ag_catalog` namespace.
 
 
 ### create_graph()
@@ -52,7 +52,7 @@ SELECT * FROM ag_catalog.create_graph('graph_name');
 
 ## Delete a Graph
 
-To delete a graph, use the drop_graph function, located in the ag_catalog namespace.
+To delete a graph, use the `drop_graph` function, located in the `ag_catalog` namespace.
 
 
 ### drop_graph()

--- a/docs/intro/graphs.md
+++ b/docs/intro/graphs.md
@@ -46,7 +46,7 @@ Considerations
 
 Example:
 
-```postgresql
+```sql
 SELECT * FROM ag_catalog.create_graph('graph_name');
 ```
 
@@ -99,13 +99,87 @@ Considerations:
 
 Example:
 
-```postgresql
+```sql
 SELECT * FROM ag_catalog.drop_graph('graph_name', true);
 ```
 
-## A Cypher Graph vs A Postgres Namespace
+## How Graphs Are Stored In Postgres
 
-Cypher uses a Postgres namespace for every individual graph. It is recommended that no DML or DDL commands are executed in the namespace that is reserved for the graph. 
+When creating graphs with AGE, a Postgres namespace will be generated for every individual graph. 
+The name and namespace of the created graphs can be seen within the `ag_graph` table from the `ag_catalog` namespace:
+```sql
+SELECT create_graph('new_graph');
+
+NOTICE:  graph "new_graph" has been created
+ create_graph 
+--------------
+
+(1 row)
+
+SELECT * FROM ag_catalog.ag_graph;
+
+   name    | namespace 
+-----------+-----------
+ new_graph | new_graph
+(1 row)
+```
+
+After creating the graph, two tables are going to be created under the graph's namespace to store vertices and edges: `_ag_label_vertex` and `_ag_label_edge`.
+These will be the parent tables of any new vertex or edge label. The query below shows how to retrieve the edge and vertex labels for all the graphs in the database.
+
+```sql
+-- Before creating a new vertex label.
+SELECT * FROM ag_catalog.ag_label;
+
+       name       | graph | id | kind |          relation          |        seq_name         
+------------------+-------+----+------+----------------------------+-------------------------
+ _ag_label_vertex | 68484 |  1 | v    | new_graph._ag_label_vertex | _ag_label_vertex_id_seq
+ _ag_label_edge   | 68484 |  2 | e    | new_graph._ag_label_edge   | _ag_label_edge_id_seq
+(2 rows)
+
+-- Creating a new vertex label.
+SELECT create_vlabel('new_graph', 'Person');
+NOTICE:  VLabel "Person" has been created
+ create_vlabel 
+---------------
+ 
+(1 row)
+
+-- After creating a new vertex label.
+SELECT * FROM ag_catalog.ag_label;
+       name       | graph | id | kind |          relation          |        seq_name         
+------------------+-------+----+------+----------------------------+-------------------------
+ _ag_label_vertex | 68484 |  1 | v    | new_graph._ag_label_vertex | _ag_label_vertex_id_seq
+ _ag_label_edge   | 68484 |  2 | e    | new_graph._ag_label_edge   | _ag_label_edge_id_seq
+ Person           | 68484 |  3 | v    | new_graph."Person"         | Person_id_seq
+(3 rows)
+
+```
+
+Whenever a vertex label is created with the `create_vlabel()` function, a new table is generated within the `new_graph`'s namespace: `new_graph."<label>"`.
+The same works for the `create_elabel()` function for the creation of edge labels. Creating vertices and edges with Cypher will automatically make these tables.
+
+```sql
+-- Creating two vertices and one edge.
+SELECT * FROM cypher('new_graph', $$
+CREATE (:Person {name: 'Daedalus'})-[:FATHER_OF]->(:Person {name: 'Icarus'})
+$$) AS (a agtype);
+ a 
+---
+(0 rows)
+
+-- Showing the newly created tables.
+SELECT * FROM ag_catalog.ag_label;
+       name       | graph | id | kind |          relation          |        seq_name         
+------------------+-------+----+------+----------------------------+-------------------------
+ _ag_label_vertex | 68484 |  1 | v    | new_graph._ag_label_vertex | _ag_label_vertex_id_seq
+ _ag_label_edge   | 68484 |  2 | e    | new_graph._ag_label_edge   | _ag_label_edge_id_seq
+ Person           | 68484 |  3 | v    | new_graph."Person"         | Person_id_seq
+ FATHER_OF        | 68484 |  4 | e    | new_graph."FATHER_OF"      | FATHER_OF_id_seq
+(4 rows)
+```
+
+_Note: It is recommended that no DML or DDL commands are executed in the namespace that is reserved for the graph._ 
 <!-- Needs clarification. Since search path is set as ag_catalog first in the searh path, all DML and DDL will happen in the ag_catalog namespace. Also should we say schema rather than namespace? 
 -->
 

--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -64,7 +64,7 @@ sudo apt install postgresql-xx postgresql-server-dev-all
 
 Clone the <a href='https://github.com/apache/age'>github repository</a> or <a href='https://github.com/apache/age/releases'>download an official release</a>
 
-Run the pg_config utility and check the version of PostgreSQL. Apache AGE supports all the stable versions of postgresql(11, 12, 13, 14 and 15).
+Run the pg_config utility and check the version of PostgreSQL. Apache AGE supports all the stable versions of PostgreSQL (11, 12, 13, 14 and 15).
 
 The build process will attempt to use the first path in the PATH environment variable when installing AGE. If the pg_config path is located there, run the following command in the source code directory of Apache AGE to build and install the extension.
 

--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -66,7 +66,7 @@ Clone the <a href='https://github.com/apache/age'>github repository</a> or <a hr
 
 Run the pg_config utility and check the version of PostgreSQL. Apache AGE supports all the stable versions of PostgreSQL (11, 12, 13, 14 and 15).
 
-The build process will attempt to use the first path in the PATH environment variable when installing AGE. If the pg_config path is located there, run the following command in the source code directory of Apache AGE to build and install the extension.
+The build process will attempt to use the first path in the PATH environment variable when installing AGE. If the `PG_CONFIG` path is located there, run the following command in the source code directory of Apache AGE to build and install the extension.
 
 ```console
 make install
@@ -81,7 +81,7 @@ make PG_CONFIG=/path/to/postgres/bin/pg_config install
 ### Post Installation AGE Setup
 
 
-After the installation, open a connection to a running instance of your database and run the CREATE EXTENSION command to have AGE installed on the server.
+After the installation, open a connection to a running instance of your database and run the `CREATE EXTENSION` command to have AGE installed on the server.
 
 ```postgresql
 CREATE EXTENSION age;
@@ -126,7 +126,7 @@ For every connection of AGE you start you will need to load the AGE extension.
 LOAD 'age';
 ```
 
-We recommend adding ag_catalog to your search_path to simplify your queries. The rest of this document will assume you have done so. If you do not, remember to add 'ag_catalog' to your cypher query function calls.
+We recommend adding `ag_catalog` to your search_path to simplify your queries. The rest of this document will assume you have done so. If you do not, remember to add `ag_catalog` to your cypher query function calls.
 
 ```postgresql
 SET search_path = ag_catalog, "$user", public;
@@ -134,7 +134,7 @@ SET search_path = ag_catalog, "$user", public;
 
 ### Allow non-superusers to use Apache AGE
 
-* Non-superusers can only apply LOAD to library files located in `$libdir/plugins/` (see <https://www.postgresql.org/docs/15/sql-load.html>). A symlink can be created to allow non-superusers to LOAD the Apache AGE library:
+* Non-superusers can only apply `LOAD` to library files located in `$libdir/plugins/` (see <https://www.postgresql.org/docs/15/sql-load.html>). A symlink can be created to allow non-superusers to `LOAD` the Apache AGE library:
 
 ```console
 sudo ln -s /usr/lib/postgresql/15/lib/age.so /usr/lib/postgresql/15/lib/plugins/age.so

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -1,6 +1,6 @@
 # Data Types - An Introduction to agtype
 
-AGE uses a custom data type called agtype, which is the only data type returned by AGE. Agtype is a superset of Json and a custom implementation of JsonB.
+AGE uses a custom data type called `agtype`, which is the only data type returned by AGE. `agtype` is a superset of Json and a custom implementation of JsonB.
 
 
 ## Simple Data Types
@@ -8,7 +8,7 @@ AGE uses a custom data type called agtype, which is the only data type returned 
 
 ### Null
 
-In Cypher, null is used to represent missing or undefined values. Conceptually, null means 'a missing unknown value' and it is treated somewhat differently from other values. For example getting a property from a vertex that does not have said property produces null. Most expressions that take null as input will produce null. This includes boolean expressions that are used as predicates in the WHERE clause. In this case, anything that is not true is interpreted as being false. null is not equal to null. Not knowing two values does not imply that they are the same value. So the expression null = null yields null and not true.
+In Cypher, `null` is used to represent missing or undefined values. Conceptually, `null` means 'a missing unknown value', and it is treated somewhat differently from other values. For example getting a property from a vertex that does not have said property produces `null`. Most expressions that take `null` as input will produce `null`. This includes boolean expressions that are used as predicates in the `WHERE` clause. In this case, anything that is not true is interpreted as being false. `null` is not equal to `null`. Not knowing two values does not imply that they are the same value. So the expression `null = null` yields `null` and not `true`.
 
 Input/Output Format
 
@@ -23,7 +23,7 @@ $$) AS (null_result agtype);
 ```
 
 
-A null will appear as an empty space.
+A `null` will appear as an empty space.
 
 Result:
 
@@ -48,7 +48,7 @@ Result:
 
 #### Agtype NULL vs Postgres NULL
 
-The concept of NULL in Agtype and Postgres is the same as it is in Cypher.
+The concept of `NULL` in `agtype` and Postgres is the same as it is in Cypher.
 
 ### Integer
 
@@ -106,9 +106,9 @@ Inexact means that some values cannot be converted exactly to the internal forma
 Values that are too large or too small will cause an error. Rounding might take place if the precision of an input number is too high. Numbers too close to zero that are not representable as distinct from zero will cause an underflow error.
 
 In addition to ordinary numeric values, the floating-point types have several special values:
-* Infinity
-* -Infinity
-* NaN
+* `Infinity`
+* `-Infinity`
+* `NaN`
 
 These represent the IEEE 754 special values “infinity”, “negative infinity”, and “not-a-number”, respectively. When writing these values as constants in a Cypher command, you must put quotes around them and typecast them, for example 
 ```
@@ -173,9 +173,9 @@ The maximum allowed precision when explicitly specified in the type declaration 
 
 If the scale of a value to be stored is greater than the declared scale of the column, the system will round the value to the specified number of fractional digits. Then, if the number of digits to the left of the decimal point exceeds the declared precision minus the declared scale, an error is raised.
 
-Numeric values are physically stored without any extra leading or trailing zeroes. Thus, the declared precision and scale of a column are maximums, not fixed allocations. (In this sense the numeric type is more akin to varchar(_n_) than to char(_n_).) The actual storage requirement is two bytes for each group of four decimal digits, plus three to eight bytes overhead.
+Numeric values are physically stored without any extra leading or trailing zeroes. Thus, the declared precision and scale of a column are maximums, not fixed allocations. (In this sense the numeric type is more akin to `varchar(n)` than to `char(n)`.) The actual storage requirement is two bytes for each group of four decimal digits, plus three to eight bytes overhead.
 
-In addition to ordinary numeric values, the numeric type allows the special value NaN, meaning “not-a-number”. Any operation on NaN yields another NaN. When writing this value as a constant in an SQL command, you must put quotes around it, for example UPDATE table SET x = 'NaN'. 
+In addition to ordinary numeric values, the numeric type allows the special value `NaN`, meaning “not-a-number”. Any operation on `NaN` yields another `NaN`. When writing this value as a constant in an SQL command, you must put quotes around it, for example `UPDATE table SET x = 'NaN'`. 
 
 
 
@@ -189,7 +189,7 @@ When rounding values, the numeric type rounds ties away from zero, while (on mos
 
 Input/Output Format:
 
-When creating a numeric data type, the ‘::numeric’ data annotation is required.
+When creating a numeric data type, the `::numeric` data annotation is required.
 
 Query
 
@@ -224,9 +224,9 @@ Result:
 
 #### Bool 
 
-AGE provides the standard Cypher type boolean. The boolean type can have several states: “true”, “false”, and a third state, “unknown”, which is represented by the Agtype null value.
+AGE provides the standard Cypher type `boolean`. The `boolean` type can have several states: “true”, “false”, and a third state, “unknown”, which is represented by the Agtype `null` value.
 
-Boolean constants can be represented in Cypher queries by the keywords TRUE, FALSE, and NULL.
+Boolean constants can be represented in Cypher queries by the keywords `TRUE`, `FALSE`, and `NULL`.
 
 Input/Output Format
 
@@ -241,7 +241,7 @@ $$) AS (boolean_result agtype);
 ```
 
 
-Unlike Postgres, AGE’s boolean outputs as the full word, ie. true and false as opposed to t and f.
+Unlike Postgres, AGE’s boolean outputs as the full word, ie. `true` and `false` as opposed to `t` and `f`.
 
 Result:
 
@@ -372,7 +372,7 @@ Result:
 
 ### List
 
-All examples will use the [WITH](../clauses/with.md) clause and [RETURN](../clauses/return.md) clause.
+All examples will use the [`WITH`](../clauses/with.md) clause and [`RETURN`](../clauses/return.md) clause.
 
 
 #### Lists in general
@@ -413,7 +413,7 @@ Result:
 
 #### NULL in a List
 
-A list can hold the value null, unlike when a null is an independent value, it will appear as the word ‘null’ in a list
+A list can hold the value `null`, and unlike when a null is an independent value, it will appear as the word ‘null’ in a list
 
 Query
 
@@ -724,7 +724,7 @@ Result:
 </table>
 
 
-Out-of-bound slices are simply truncated, but out-of-bound single elements return null.
+Out-of-bound slices are simply truncated, but out-of-bound single elements return `null`.
 
 Query
 
@@ -955,7 +955,7 @@ A label is an identifier that classifies vertices and edges into certain categor
 * Edges are required to have a label, but vertices do not. 
 * The names of labels between vertices and edges cannot overlap. 
 
-See [CREATE](../clauses/create.md) clause for information about how to make entities with labels.
+See [`CREATE`](../clauses/create.md) clause for information about how to make entities with labels.
 
 
 ### Properties

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -1067,13 +1067,13 @@ Data Format
   <tr>
    <td>startid
    </td>
-   <td>graphid for the incoming edge
+   <td>graphid for the source node
    </td>
   </tr>
   <tr>
    <td>endid
    </td>
-   <td>graphid for the outgoing edge
+   <td>graphid for the target node
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
It's easier to identify the SQL clause WHERE when written as an in-line code, `WHERE`.

This PR updates all SQL commands, Cypher commands, AGE and PostgreSQL data types in the **Introduction** section of the documentation to in-line codes.

Along with it are corrections to a few minor typographical errors.