### PR TITLE
In-line code formatting for AGE clauses in the Clauses Section

### DIFF
--- a/docs/clauses/create.md
+++ b/docs/clauses/create.md
@@ -1,11 +1,11 @@
 # CREATE
 
-The CREATE clause is used to create graph vertices and edges. 
+The `CREATE` clause is used to create graph vertices and edges. 
 
 
 ## Terminal CREATE clauses
 
-A create clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `CREATE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 Query
 
@@ -275,7 +275,7 @@ Result
 
 
 ## Create a full path
-When you use CREATE and a pattern, all parts of the pattern that are not already in scope at this time will be created.
+When you use `CREATE` and a pattern, all parts of the pattern that are not already in scope at this time will be created.
 
 Query
 

--- a/docs/clauses/delete.md
+++ b/docs/clauses/delete.md
@@ -1,22 +1,22 @@
 # DELETE
 
-The DELETE clause is used to delete graph elements—nodes, relationships orpaths.
+The `DELETE` clause is used to delete graph elements—nodes, relationships orpaths.
 
 ## Terminal DELETE clauses
 
-A delete clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `DELETE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Introduction
 
-For removing properties, see REMOVE.
+For removing properties, see `REMOVE`.
 
-You cannot delete a node without also deleting edges that start or end on said vertex. Either explicitly delete the vertices,or use DETACH DELETE.
+You cannot delete a node without also deleting edges that start or end on said vertex. Either explicitly delete the vertices,or use `DETACH DELETE`.
 
 
 ## Delete single vertex
 
-To delete a vertex, use the DELETE clause.
+To delete a vertex, use the `DELETE` clause.
 
 Query
 
@@ -46,7 +46,7 @@ Nothing is returned from this query.
 
 ## Delete all vertices and edges
 
-Running a Match clause will collect all nodes, use the DETACH option to first delete a vertice's edges then delete the vertex itself.
+Running a Match clause will collect all nodes, use the `DETACH` option to first delete a vertice's edges then delete the vertex itself.
 
 Query
 
@@ -76,7 +76,7 @@ Nothing is returned from this query.
 
 ## Delete edges only
 
-To delete an edge, use the match clause to find your edges, then add the variable to the DELETE.
+To delete an edge, use the match clause to find your edges, then add the variable to the `DELETE`.
 
 Query
 ```postgresql

--- a/docs/clauses/limit.md
+++ b/docs/clauses/limit.md
@@ -1,10 +1,10 @@
 # LIMIT
 
-LIMIT constrains the number of records in the output.
+`LIMIT` constrains the number of records in the output.
 
 ## Introduction
 
-LIMIT accepts any expression that evaluates to a positive integer.
+`LIMIT` accepts any expression that evaluates to a positive integer.
 
 
 ## Return a subset of the rows
@@ -54,7 +54,7 @@ Result
 
 ## Using an expression with LIMIT to return a subset of the rows
 
-Limit accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:
+`LIMIT` accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:
 
 Query
 

--- a/docs/clauses/match.md
+++ b/docs/clauses/match.md
@@ -1,12 +1,12 @@
 # MATCH
 
-The MATCH clause allows you to specify the patterns Cypher will search for in the database. This is the primary way of getting data into the current set of bindings. It is worth reading up more on the specification of the patterns themselves in Patterns.
+The `MATCH` clause allows you to specify the patterns Cypher will search for in the database. This is the primary way of getting data into the current set of bindings. It is worth reading up more on the specification of the patterns themselves in Patterns.
 
-MATCH is often coupled to a WHERE part which adds restrictions, or predicates, to the MATCH patterns, making them more specific. The predicates are part of the pattern description, and should not be considered a filter applied only after the matching is done. This means that WHERE should always be put together with the MATCH clause it belongs to.
+`MATCH` is often coupled to a `WHERE` part which adds restrictions, or predicates, to the `MATCH` patterns, making them more specific. The predicates are part of the pattern description, and should not be considered a filter applied only after the matching is done. This means that `WHERE` should always be put together with the `MATCH` clause it belongs to.
 
-MATCH can occur at the beginning of the query or later, possibly after a WITH. If it is the first clause, nothing will have been bound yet, and Cypher will design a search to find the results matching the clause and any associated predicates specified in any WHERE part. Vertices and edges found by this search are available as bound pattern elements, and can be used for pattern matching of sub-graphs. They can also be used in any future clauses, where Cypher will use the known elements, and from there find further unknown elements.
+MATCH can occur at the beginning of the query or later, possibly after a `WITH`. If it is the first clause, nothing will have been bound yet, and Cypher will design a search to find the results matching the clause and any associated predicates specified in any `WHERE` part. Vertices and edges found by this search are available as bound pattern elements, and can be used for pattern matching of sub-graphs. They can also be used in any future clauses, where Cypher will use the known elements, and from there find further unknown elements.
 
-Cypher is declarative, and so usually the query itself does not specify the algorithm to use to perform the search. Predicates in WHERE parts can be evaluated before pattern matching, during pattern matching, or after finding matches.
+Cypher is declarative, and so usually the query itself does not specify the algorithm to use to perform the search. Predicates in `WHERE` parts can be evaluated before pattern matching, during pattern matching, or after finding matches.
 
 
 ## Basic vertex finding
@@ -111,7 +111,7 @@ Returns all the movies in the database.
 
 ### Related Vertices
 
-The symbol -[]- means related to, without regard to type or direction of the edge.
+The symbol `-[]-` means related to, without regard to type or direction of the edge.
 
 Query
 
@@ -124,7 +124,7 @@ $$) as (title agtype);
 ```
 
 
-Returns all the movies directed by 'Oliver Stone'
+Returns all the movies directed by 'Oliver Stone'.
 
 
 <table>
@@ -159,7 +159,7 @@ $$) as (title agtype);
 ```
 
 
-Returns any vertices connected with the Person 'Oliver' that are labeled Movie.
+Returns any vertices connected with the `Person` 'Oliver' that are labeled `Movie`.
 
 
 <table>
@@ -184,7 +184,7 @@ Returns any vertices connected with the Person 'Oliver' that are labeled Movie.
 
 ### Outgoing Edges
 
-When the direction of an edge is of interest, it is shown by using -> or &lt;-.
+When the direction of an edge is of interest, it is shown by using `->` or `<-`.
 
 Query
 
@@ -197,7 +197,7 @@ $$) as (title agtype);
 ```
 
 
-Returns any vertices connected with the Person'Oliver' by an outgoing edge.
+Returns any vertices connected with the `Person` 'Oliver' by an outgoing edge.
 
 
 <table>
@@ -267,7 +267,7 @@ $$) as (actors_name agtype);
 ```
 
 
-Returns all actors that ACTED_IN'Wall Street'.
+Returns all actors that `ACTED_IN` 'Wall Street'.
 
 
 <table>
@@ -310,7 +310,7 @@ $$) as (role agtype);
 ```
 
 
-Returns ACTED_IN roles for 'Wall Street'.
+Returns `ACTED_IN` roles for 'Wall Street'.
 
 
 <table>
@@ -340,7 +340,7 @@ Returns ACTED_IN roles for 'Wall Street'.
 
 ### Multiple Edges
 
-Edges can be expressed by using multiple statements in the form of ()-[]-(), or they can be strung together.
+Edges can be expressed by using multiple statements in the form of `()-[]-()`, or they can be strung together.
 
 Query
 
@@ -394,7 +394,7 @@ Which describes a right directed path of three vertices and two edges can be rew
 (u)-[]->()-[]->(v)
 ```
 
-A range lengths can also be given:
+A range length can also be given:
 
 
 ```
@@ -409,26 +409,26 @@ Which is equivalent to:
 (u)-[]->()-[]->()-[]->()-[]->()-[]->(v)
 ```
 
-The previous example provided gave the edge both an lower and upper bound for the number of edges (and vertices) between u and v. Either one or both of these binding values can be excluded
+The previous example provided gave the edge both an lower and upper bound for the number of edges (and vertices) between `u` and `v`. Either one or both of these binding values can be excluded.
 
 
 ```
 (u)-[*3..]->(v)
 ```
 
-Returns all paths between u and v that have three or more edges included.
+Returns all paths between `u` and `v` that have three or more edges included.
 
 ```
 (u)-[*..5]->(v)
 ```
 
-Returns all paths between u and v that have 5 or fewer edges included.
+Returns all paths between `u` and `v` that have 5 or fewer edges included.
 
 ```
 (u)-[*]->(v)
 ```
 
-Returns all paths between u and v
+Returns all paths between `u` and `v`.
 
 
 ### Example
@@ -439,13 +439,13 @@ Query
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
-    MATCH p = (actor {name: 'Willam Defoe'})-[:ACTED_IN*2]-(co_actor)
+    MATCH p = (actor {name: 'Willam Dafoe'})-[:ACTED_IN*2]-(co_actor)
     RETURN relationships(p)
 $$) as (r agtype);
 ```
 
 
-Returns the list of edges, including the one that Willam Defoe acted in and the two spidermens he worked with.
+Returns the list of edges, including the one that Willam Dafoe acted in and the two Spiderman actors he worked with.
 
 
 <table>

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -1,13 +1,13 @@
 # MERGE
 
-The MERGE clause ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
+The `MERGE` clause ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
 
 
-MERGE either matches existing nodes, or creates new data. It’s a combination of MATCH and CREATE.
+`MERGE` either matches existing nodes, or creates new data. It’s a combination of `MATCH` and `CREATE`.
 
-For example, you can specify that the graph must contain a node for a user with a certain name. If there isn’t a node with the correct name, a new node will be created and its name property set. When using MERGE on full patterns, the behavior is that either the whole pattern matches, or the whole pattern is created. MERGE will not partially use existing patterns. If partial matches are needed, this can be accomplished by splitting a pattern up into multiple MERGE clauses.
+For example, you can specify that the graph must contain a node for a user with a certain name. If there isn’t a node with the correct name, a new node will be created and its name property set. When using `MERGE` on full patterns, the behavior is that either the whole pattern matches, or the whole pattern is created. `MERGE` will not partially use existing patterns. If partial matches are needed, this can be accomplished by splitting a pattern up into multiple `MERGE` clauses.
 
-As with MATCH, MERGE can match multiple occurrences of a pattern. If there are multiple matches, they will all be passed on to later stages of the query.
+As with `MATCH`, `MERGE` can match multiple occurrences of a pattern. If there are multiple matches, they will all be passed on to later stages of the query.
 
 ## Data Setup
 
@@ -101,7 +101,7 @@ RETURN michael.name, michael.bornIn
 $$) as (Name agtype, BornIn agtype);
 ```
 
-'Michael Douglas' will match the existing vertex and the vertex's name and bornIn properties returned.
+'Michael Douglas' will match the existing vertex and the vertex's `name` and `bornIn` properties returned.
 
 <table>
   <tr>

--- a/docs/clauses/order_by.md
+++ b/docs/clauses/order_by.md
@@ -1,19 +1,19 @@
 # ORDER BY
 
-ORDER BY is a sub-clause following WITH, and it specifies that the output should be sorted and how. 
+`ORDER BY` is a sub-clause following `WITH`, and it specifies that the output should be sorted and how. 
 
 ## Introduction
 
-Note that you cannot sort on nodes or relationships, just on properties on these. ORDER BY relies on comparisons to sort the output, see Ordering and comparison of values.
+Note that you cannot sort on nodes or relationships, just on properties on these. `ORDER BY` relies on comparisons to sort the output, see Ordering and comparison of values.
 
-In terms of scope of variables, ORDER BY follows special rules, depending on if the projecting RETURN or WITH clause is either aggregating or DISTINCT. If it is an aggregating or DISTINCT projection, only the variables available in the projection are available. If the projection does not alter the output cardinality (which aggregation and DISTINCT do), variables available from before the projecting clause are also available. When the projection clause shadows already existing variables, only the new variables are available.
+In terms of scope of variables, `ORDER BY` follows special rules, depending on if the projecting `RETURN` or `WITH` clause is either aggregating or `DISTINCT`. If it is an aggregating or `DISTINCT` projection, only the variables available in the projection are available. If the projection does not alter the output cardinality (which aggregation and `DISTINCT` do), variables available from before the projecting clause are also available. When the projection clause shadows already existing variables, only the new variables are available.
 
-Lastly, it is not allowed to use aggregating expressions in the ORDER BY sub-clause if they are not also listed in the projecting clause. This last rule is to make sure that ORDER BY does not change the results, only the order of them.
+Lastly, it is not allowed to use aggregating expressions in the `ORDER BY` sub-clause if they are not also listed in the projecting clause. This last rule is to make sure that `ORDER BY` does not change the results, only the order of them.
 
 
 ## Order nodes by property
 
-ORDER BY is used to sort the output.
+`ORDER BY` is used to sort the output.
 
 Query
 
@@ -69,7 +69,7 @@ Result
 
 ## Order nodes by multiple properties
 
-You can order by multiple properties by stating each variable in the ORDER BY clause. Cypher will sort the result by the first variable listed, and for equal values, go to the next property in the ORDER BY clause, and so on.
+You can order by multiple properties by stating each variable in the `ORDER BY` clause. Cypher will sort the result by the first variable listed, and for equal values, go to the next property in the `ORDER BY` clause, and so on.
 
 Query
 
@@ -125,7 +125,7 @@ Result
 
 ## Order nodes in descending order
 
-By adding DESC[ENDING] after the variable to sort on, the sort will be done in reverse order.
+By adding `DESC[ENDING]` after the variable to sort on, the sort will be done in reverse order.
 
 Query
 

--- a/docs/clauses/remove.md
+++ b/docs/clauses/remove.md
@@ -1,16 +1,16 @@
 # REMOVE
 
-The REMOVE clause is used to remove properties from vertex and edges.
+The `REMOVE` clause is used to remove properties from vertex and edges.
 
 
 ## Terminal REMOVE clauses
 
-A remove clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `REMOVE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Remove a property
 
-Cypher doesn’t allow storing null in properties. Instead, if no value exists, the property is just not there. So, to remove a property value on a node or a relationship, is also done with REMOVE.113
+Cypher doesn’t allow storing `null` in properties. Instead, if no value exists, the property is just not there. So, removing a property value on a node or a relationship is also done with `REMOVE`.
 
 Query
 

--- a/docs/clauses/return.md
+++ b/docs/clauses/return.md
@@ -1,11 +1,11 @@
 # RETURN  
 
-In the RETURN part of your query, you define which parts of the pattern you are interested in. It can be nodes, relationships, or properties on these.
+In the `RETURN` part of your query, you define which parts of the pattern you are interested in. It can be nodes, relationships, or properties on these.
 
 
 ## Return nodes
 
-To return a node, list it in the RETURN statement.
+To return a node, list it in the `RETURN` statement.
 
 Query
 
@@ -43,7 +43,7 @@ Result
 
 ## Return edges
 
-To return n edge, just include it in the RETURN list.
+To return `n`'s edges, just include it in the `RETURN` list.
 
 Query
 
@@ -117,7 +117,7 @@ Result
 
 ## Return all elements
 
-When you want to return all vertices, edges and paths found in a query, you can use the * symbol.
+When you want to return all vertices, edges and paths found in a query, you can use the `*` symbol.
 
 Query
 
@@ -163,7 +163,7 @@ Result
    </td>
   </tr>
   <tbody>
-   <td>(2 rows)
+   <td colspan="3">(2 rows)
    </td>
   </tr>
 </table>
@@ -335,7 +335,7 @@ Result
 
 ## Unique results
 
-DISTINCT retrieves only unique records depending on the fields that have been selected to output.
+`DISTINCT` retrieves only unique records depending on the fields that have been selected to output.
 
 Query
 

--- a/docs/clauses/set.md
+++ b/docs/clauses/set.md
@@ -1,16 +1,16 @@
 # SET
 
-The SET clause is used to update labels on nodes and properties on vertices and edges
+The `SET` clause is used to update labels on nodes and properties on vertices and edges
 
 
 ## Terminal SET clauses
 
-A set clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `SET` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Set a property
 
-To set a property on a node or relationship, use SET.
+To set a property on a node or relationship, use `SET`.
 
 Query
 
@@ -83,7 +83,7 @@ Result
 
 ## Remove a property
 
-Normally you remove a property by using REMOVE, but it’s sometimes handy to do it using the SET command. One example is if the property comes from a parameter.
+Normally you remove a property by using `REMOVE`, but it’s sometimes handy to do it using the `SET` command. One example is if the property comes from a parameter.
 
 Query
 

--- a/docs/clauses/skip.md
+++ b/docs/clauses/skip.md
@@ -1,10 +1,10 @@
 # SKIP
 
-SKIP defines from which record to start including the records in the output.
+`SKIP` defines from which record to start including the records in the output.
 
 ## Introduction
 
-By using SKIP, the result set will get trimmed from the top. Please note that no guarantees are made on the order of the result unless the query specifies the ORDER BY clause. SKIP accepts any expression that evaluates to a positive  integer.
+By using `SKIP`, the result set will get trimmed from the top. Please note that no guarantees are made on the order of the result unless the query specifies the `ORDER BY` clause. `SKIP` accepts any expression that evaluates to a positive  integer.
 
 ## Skip first three rows
 
@@ -92,7 +92,7 @@ Result
 
 ## Using an expression with SKIP to return a subset of the rows
 
-Using an expression with SKIP to return a subset of the rows
+Using an expression with `SKIP` to return a subset of the rows
 
 Query
 

--- a/docs/clauses/with.md
+++ b/docs/clauses/with.md
@@ -2,16 +2,16 @@
 
 ## Introduction
 
-Using WITH, you can manipulate the output before it is passed on to the following query parts. The manipulations can be of the shape and/or number of entries in the result set.
+Using `WITH`, you can manipulate the output before it is passed on to the following query parts. The manipulations can be of the shape and/or number of entries in the result set.
 
-WITH can also, like RETURN, alias expressions that are introduced into the results using the aliases as the binding name.
+`WITH` can also, like `RETURN`, alias expressions that are introduced into the results using the aliases as the binding name.
 
-WITH is also used to separate the reading of the graph from updating of the graph. Every part of a query must be either read-only or write-only. When going from a writing part to a reading part, the switch can be done with an optional WITH clause.
+`WITH` is also used to separate the reading of the graph from updating of the graph. Every part of a query must be either read-only or write-only. When going from a writing part to a reading part, the switch can be done with an optional `WITH` clause.
 
 
 ## Filter on aggregate function results
 
-Aggregated results have to pass through a WITH clause to be able to filter on.
+Aggregated results have to pass through a `WITH` clause to be able to filter on.
 
 Query
 ```postgresql
@@ -88,7 +88,7 @@ Result
 
 ## Limit branching of a path search
 
-You can match paths, limit to a certain number, and then match again using those paths as a base,as well as any number of similar limited searches.
+You can match paths, limit to a certain number, and then match again using those paths as a base, as well as any number of similar limited searches.
 
 Query
 
@@ -103,7 +103,7 @@ $$) as (name agtype);
 ```
 
 
-Starting at 'Anders', find all matching nodes, order by name descending and get the top result, thenfind all the nodes connected to that top result, and return their names.
+Starting at 'Anders', find all matching nodes, order by name descending and get the top result, then find all the nodes connected to that top result, and return their names.
 
 Result
 <table>


### PR DESCRIPTION
It's easier to identify the SQL clause WHERE when formatted as an in-line code, `WHERE`.

This PR formats all AGE clauses and data types in the **Clauses** section of the documentation to in-line codes.

Along with it are corrections to a few minor typographical errors.