### PR TITLE
In-line code formatting for AGE clauses in the Functions Section

### DIFF
--- a/docs/functions/aggregate_functions.md
+++ b/docs/functions/aggregate_functions.md
@@ -25,7 +25,7 @@ $$) as (a agtype);
 
 ## min
 
-min() returns the minimum value in a set of values.
+`min()` returns the minimum value in a set of values.
 
 
 Syntax: `min(expression)`
@@ -62,9 +62,9 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* In a mixed set, any string value is always considered to be lower than any numeric value, and anylist is always considered to be lower than any string.
+* In a mixed set, any string value is always considered to be lower than any numeric value, and any list is always considered to be lower than any string.
 * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end.
-* min(null) returns null.
+* `min(null)` returns null.
 
 Query
 
@@ -156,7 +156,7 @@ Result:
 
 ## max
 
-max() returns the maximum value in a set of values.
+`max()` returns the maximum value in a set of values.
 
 Syntax: `max(expression)`
 
@@ -194,7 +194,7 @@ Considerations:
 * Any null values are excluded from the calculation.
 * In a mixed set, any numeric value is always considered to be higher than any string value, and anystring value is always considered to be higher than any list.
 * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end.
-* max(null) returns null.
+* `max(null)` returns null.
 
 Query:
 
@@ -232,7 +232,7 @@ Result:
 
 ## stDev
 
-stDev() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N - 1 as the denominator, and should be used when taking a sample of the population for an unbiased estimate. When the standard variation of the entire population is being calculated, stdDevP should be used.
+`stDev()` returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N - 1 as the denominator, and should be used when taking a sample of the population for an unbiased estimate. When the standard variation of the entire population is being calculated, `stdDevP` should be used.
 
 Syntax: `stDev(expression)`
 
@@ -268,7 +268,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* stDev(null) returns 0.
+* `stDev(null)` returns 0.
 
 Query
 
@@ -306,7 +306,7 @@ Result:
 
 ## stDevP
 
-stDevP() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N as the denominator, and should be used when calculating the standard deviation for an entire population. When the standard variation of only a sample of the population is being calculated, stDev should be used.
+`stDevP()` returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N as the denominator, and should be used when calculating the standard deviation for an entire population. When the standard variation of only a sample of the population is being calculated, `stDev` should be used.
 
 Syntax: `stDevP(expression)`
 
@@ -342,7 +342,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* stDevP(null) returns 0.
+* `stDevP(null)` returns 0.
 
 Query
 
@@ -380,7 +380,7 @@ Result:
 
 ## percentileCont
 
-percentileCont() returns the percentile of the given value over a group, with a percentile from 0.0 to 1.0. It uses a linear interpolation method, calculating a weighted average between two values if the desired percentile lies between them. For nearest values using a rounding method, see percentileDisc.
+`percentileCont()` returns the percentile of the given value over a group, with a percentile from 0.0 to 1.0. It uses a linear interpolation method, calculating a weighted average between two values if the desired percentile lies between them. For nearest values using a rounding method, see `percentileDisc`.
 
 Syntax: `percentileCont(expression, percentile)`
 
@@ -422,7 +422,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* percentileCont(null, percentile) returns null.
+* `percentileCont(null, percentile)` returns null.
 
 Query
 
@@ -460,7 +460,7 @@ Result:
 
 ## percentileDisc
 
-percentileDisc() returns the percentile of the given value over a group, with a percentile from 0.0to 1.0. It uses a rounding method and calculates the nearest value to the percentile. For interpolated values, see percentileCont.
+`percentileDisc()` returns the percentile of the given value over a group, with a percentile from 0.0 to 1.0. It uses a rounding method and calculates the nearest value to the percentile. For interpolated values, see `percentileCont`.
 
 Syntax: `percentileDisc(expression, percentile)`
 
@@ -502,7 +502,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* percentileDisc(null, percentile) returns null.
+* `percentileDisc(null, percentile)` returns null.
 
 Query
 
@@ -540,12 +540,12 @@ Result:
 
 ## count
 
-count() returns the number of values or records, and appears in two variants:
+`count()` returns the number of values or records, and appears in two variants:
 
 
 
-* count(*) returns the number of matching records
-* count(expr) returns the number of non-null values returned by an expression.
+* `count(*)` returns the number of matching records
+* `count(expr)` returns the number of non-null values returned by an expression.
 
 Syntax: `count(expression)`
 
@@ -577,11 +577,11 @@ Arguments:
 
 
 Considerations:
-* count(*) includes records returning null.
-* count(expr) ignores null values.
-* count(null) returns 0.
-* Using count(*) to return the number of nodes
-* count(*) can be used to return the number of nodes; for example, the number of nodes connected to some node n.
+* `count(*)` includes records returning null.
+* `count(expr)` ignores null values.
+* `count(null)` returns 0.
+* Using `count(*)` to return the number of nodes
+* `count(*)` can be used to return the number of nodes; for example, the number of nodes connected to some node n.
 
 
 Query
@@ -593,7 +593,7 @@ FROM cypher('graph_name', $$
 $$) as (age agtype, number_of_people agtype);
 ```
 
-The labels and age property of the start node n and the number of nodes related to n are returned.
+The labels and age property of the start node `n` and the number of nodes related to `n` are returned.
 
 Result:
 <table>
@@ -616,7 +616,7 @@ Result:
 </table>
 
 
-Using count(*) to group and count relationship typescount(*) can be used to group relationship types and return the number.
+Using `count(*)` to group and count relationship `typescount(*)` can be used to group relationship types and return the number.
 
 Query
 ```postgresql
@@ -656,7 +656,7 @@ Result:
 
 ### Using count(expression) to return the number of values
 
-Instead of simply returning the number of records with count(*), it may be more useful to return the actual number of values returned by an expression.
+Instead of simply returning the number of records with `count(*)`, it may be more useful to return the actual number of values returned by an expression.
 
 Query
 
@@ -694,7 +694,7 @@ Result:
 
 ### Counting non-null values
 
-count(expression) can be used to return the number of non-null values returned by the expression.
+`count(expression)` can be used to return the number of non-null values returned by the expression.
 
 Query
 
@@ -708,7 +708,7 @@ $$) as (count agtype);
 ```
 
 
-The number of :Person nodes having an age property is returned.
+The number of `:Person` nodes having an age property is returned.
 
 Result:
 
@@ -732,8 +732,8 @@ Result:
 ### Counting with and without duplicates
 
 In this example we are trying to find all our friends of friends, and count them:
-* The first aggregate function, count(DISTINCT friend_of_friend), will only count a friend_of_friend once, as DISTINCT removes the duplicates.
-* The second aggregate function, count(friend_of_friend), will consider the same friend_of_friend multiple times.
+* The first aggregate function, `count(DISTINCT friend_of_friend)`, will only count a `friend_of_friend` once, as `DISTINCT` removes the duplicates.
+* The second aggregate function, `count(friend_of_friend)`, will consider the same `friend_of_friend` multiple times.
 
 Query
 ```postgresql
@@ -745,7 +745,7 @@ FROM cypher('graph_name', $$
 $$) as (friend_of_friends_distinct agtype, friend_of_friends agtype);
 ```
 
-Both B and C know D and thus D will get counted twice when not using DISTINCT
+Both `B` and `C` know `D` and thus `D` will get counted twice when not using `DISTINCT`.
 
 Result:
 <table>
@@ -770,7 +770,7 @@ Result:
 
 ## avg
 
-avg() returns the average of a set of numeric values.
+`avg()` returns the average of a set of numeric values.
 
 Syntax: `avg(expression)`
 
@@ -806,7 +806,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* avg(null) returns null.
+* `avg(null)` returns null.
 
 Query
 
@@ -844,7 +844,7 @@ Result:
 
 ## sum 
 
-sum() returns the sum of a set of numeric values.
+`sum()` returns the sum of a set of numeric values.
 
 Syntax: `sum(expression)`
 
@@ -880,7 +880,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* sum(null) returns 0.
+* `sum(null)` returns 0.
 
 Query
 

--- a/docs/functions/list_functions.md
+++ b/docs/functions/list_functions.md
@@ -19,9 +19,9 @@ $$) as (result agtype);
 
 ## keys
 
-keys returns a list containing the string representations for all the property names of a vertex, edge, or map.
+`keys()` returns a list containing the string representations for all the property names of a vertex, edge, or map.
 
-Syntax:`keys(expression)`
+Syntax: `keys(expression)`
 
 Returns:
 ```
@@ -45,7 +45,7 @@ Arguments:
 </table>
 
 Considerations:
-* keys(null) returns null.
+* `keys(null)` returns null.
 
 Query:
 ```postgresql
@@ -77,9 +77,9 @@ Result:
 
 ## range
 
-range() returns a list comprising all integer values within a range bounded by a start value **start** and end value **end**, where the difference **step** between any two consecutive values is constant; i.e. an arithmetic progression. The range is  inclusive, and the arithmetic progression will therefore always contain **start** and—depending on the values of **start**, **step** and **end**—**end**.
+`range()` returns a list comprising all integer values within a range bounded by a start value **start** and end value **end**, where the difference **step** between any two consecutive values is constant; i.e. an arithmetic progression. The range is  inclusive, and the arithmetic progression will therefore always contain **start** and—depending on the values of **start**, **step** and **end**—**end**.
 
-Syntax:`range(start, end [, step])`
+Syntax: `range(start, end [, step])`
 
 Returns:
 ```
@@ -144,9 +144,9 @@ Result:
 
 ## labels
 
-labels returns a list containing the string representations for all the labels of a node.
+`labels()` returns a list containing the string representations for all the labels of a node.
 
-Syntax:`labels(vertex)`
+Syntax: `labels(vertex)`
 
 Returns:
 ```
@@ -170,7 +170,7 @@ Arguments:
 </table>
 
 Considerations:
-* labels(null) returns null.
+* `labels(null)` returns null.
 
 Query:
 ```postgresql
@@ -202,9 +202,9 @@ Result:
 
 ## nodes
 
-nodes returns a list containing all the vertices in a path.
+`nodes()` returns a list containing all the vertices in a path.
 
-Syntax:`nodes(path)`
+Syntax: `nodes(path)`
 
 Returns:
 ```
@@ -228,7 +228,7 @@ Arguments:
 </table>
 
 Considerations:
-* nodes(null) returns null.
+* `nodes(null)` returns null.
 
 Query:
 ```postgresql
@@ -240,7 +240,7 @@ FROM cypher('graph_name', $$
 $$) as (vertices agtype);
 ```
 
-A list containing all the vertices in the path p is returned.
+A list containing all the vertices in the path `p` is returned.
 
 Result:
 <table>
@@ -260,9 +260,9 @@ Result:
 
 ## relationships
 
-relationships() returns a list containing all the relationships in a path.
+`relationships()` returns a list containing all the relationships in a path.
 
-Syntax:`relationships(path)`
+Syntax: `relationships(path)`
 
 Returns:
 ```
@@ -286,7 +286,7 @@ Arguments:
 </table>
 
 Considerations:
-* relationships(null) returns null.
+* `relationships(null)` returns null.
 
 Query:
 ```postgresql
@@ -298,7 +298,7 @@ FROM cypher('graph_name', $$
 $$) as (edges agtype);
 ```
 
-A list containing all the edges in the path p is returned.
+A list containing all the edges in the path `p` is returned.
 
 Result:
 <table>

--- a/docs/functions/logarithmic_functions.md
+++ b/docs/functions/logarithmic_functions.md
@@ -3,9 +3,9 @@
 
 ## e
 
-e() returns the base of the natural logarithm, e.
+`e()` returns the base of the natural logarithm, e.
 
-Syntax:e()
+Syntax: `e()`
 
 Returns:
 
@@ -48,9 +48,9 @@ Results
 
 ## sqrt
 
-sqrt() returns the square root of a number.
+`sqrt()` returns the square root of a number.
 
-Syntax:sqrt(expression)
+Syntax: `sqrt(expression)`
 
 Returns:
 
@@ -93,7 +93,7 @@ Results
 
 ## exp
 
-exp() returns e^n, where e is the base of the natural logarithm, and n is the value of the argument expression.
+`exp()` returns e^n, where e is the base of the natural logarithm, and n is the value of the argument expression.
 
 Syntax: `exp(expression)`
 
@@ -101,7 +101,7 @@ Returns:
 
 
 ```
-An agtype Float.
+An agtype float.
 ```
 
 
@@ -128,7 +128,7 @@ Considerations:
 
 
 
-* exp(null) returns null.
+* `exp(null)` returns null.
 
 Query:
 
@@ -165,15 +165,15 @@ Result:
 
 ## log
 
-log() returns the natural logarithm of a number.
+`log()` returns the natural logarithm of a number.
 
-Syntax:`log(expression)`
+Syntax: `log(expression)`
 
 Returns:
 
 
 ```
-An agtype Float.
+An agtype float.
 ```
 
 
@@ -200,8 +200,8 @@ Considerations:
 
 
 
-* log(null) returns null.
-* log(0) returns null.
+* `log(null)` returns null.
+* `log(0)` returns null.
 
 Query:
 
@@ -238,15 +238,15 @@ Result:
 
 ## log10
 
-log10() returns the common logarithm (base 10) of a number.
+`log10()` returns the common logarithm (base 10) of a number.
 
-Syntax:`log10(expression)`
+Syntax: `log10(expression)`
 
 Returns:
 
 
 ```
-An agtype Float.
+An agtype float.
 ```
 
 
@@ -273,8 +273,8 @@ Considerations:
 
 
 
-* log10(null) returns null.
-* log10(0) returns null.
+* `log10(null)` returns null.
+* `log10(0)` returns null.
 
 Query:
 

--- a/docs/functions/numeric_functions.md
+++ b/docs/functions/numeric_functions.md
@@ -3,7 +3,7 @@
 
 ## rand
 
-rand() returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e.[0,1). The numbers returned follow an approximate uniform distribution.
+`rand()` returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e.[0,1). The numbers returned follow an approximate uniform distribution.
 
 Syntax: `rand()`
 
@@ -11,7 +11,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -50,7 +50,7 @@ Result:
 
 ## abs
 
-abs() returns the absolute value of the given number.
+`abs()` returns the absolute value of the given number.
 
 Syntax: `abs(expression)`
 
@@ -85,7 +85,7 @@ Considerations:
 
 
 
-* abs(null) returns null.
+* `abs(null)` returns null.
 * If expression is negative, -(expression) (i.e. the negation of expression) is returned.
 
 Query:
@@ -132,7 +132,7 @@ Result:
 
 ## ceil
 
-ceil() returns the smallest floating point number that is greater than or equal to the given number and equal to a mathematical integer.
+`ceil()` returns the smallest floating point number that is greater than or equal to the given number and equal to a mathematical integer.
 
 Syntax: `ceil(expression)`
 
@@ -140,7 +140,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -167,7 +167,7 @@ Considerations:
 
 
 
-* ceil(null) returns null.
+* `ceil(null)` returns null.
 
 Query:
 
@@ -204,7 +204,7 @@ Result:
 
 ## floor
 
-floor() returns the greatest floating point number that is less than or equal to the given number and equal to a mathematical integer.
+`floor()` returns the greatest floating point number that is less than or equal to the given number and equal to a mathematical integer.
 
 Syntax: `floor(expression)`
 
@@ -212,7 +212,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -241,7 +241,7 @@ Considerations:
 
 
 
-* floor(null) returns null.
+* `floor(null)` returns null.
 
 Query:
 
@@ -278,7 +278,7 @@ Result:
 
 ## round
 
-round() returns the value of the given number rounded to the nearest integer.
+`round()` returns the value of the given number rounded to the nearest integer.
 
 Syntax: `round(expression)`
 
@@ -286,7 +286,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -309,13 +309,11 @@ Arguments:
 </table>
 
 
-`
-
 Considerations:
 
 
 
-* round(null) returns null.
+* `round(null)` returns null.
 
 Query:
 
@@ -352,13 +350,13 @@ Result:
 
 ## sign
 
-sign() returns the signum of the given number: 0 if the number is 0, -1 for any negative number, and 1 for any positive number
+`sign()` returns the signum of the given number: 0 if the number is 0, -1 for any negative number, and 1 for any positive number
 
-Syntax:sign(expression)
+Syntax: `sign(expression)`
 
 Returns:
 
-An Integer.
+An integer.
 
 Arguments:
 
@@ -383,7 +381,7 @@ Considerations:
 
 
 
-* sign(null) returns null.
+* `sign(null)` returns null.
 
 Query:
 

--- a/docs/functions/predicate_functions.md
+++ b/docs/functions/predicate_functions.md
@@ -1,17 +1,17 @@
 # Predicate Functions
 
-Predicates are boolean functions that return true or false for a given set of input. They are most commonly used to filter out subgraphs in the WHERE part of a query.
+Predicates are boolean functions that return true or false for a given set of input. They are most commonly used to filter out subgraphs in the `WHERE` part of a query.
 
 
 ## Exists(Property)
 
-exists() returns true if the specified property exists in the node, relationship or map. This is different from the EXISTS clause.
+`exists()` returns true if the specified property exists in the node, relationship or map. This is different from the `EXISTS` clause.
 
-Syntax:exists(property)
+Syntax: `exists(property)`
 
 Returns:
 
-An agtype boolean
+An agtype boolean.
 
 Arguments:
 
@@ -76,13 +76,13 @@ Results:
 
 ## Exists(Path)
 
-EXISTS(path) returns true if for the given path, there already exists the given path.
+`EXISTS(path)` returns true if for the given path, there already exists the given path.
 
 ```postgresql
 SELECT *
 FROM cypher('graph_name', $$
      MATCH (n)
-     WHERE exists((n)-[]-({name: 'Willem Defoe'}))
+     WHERE exists((n)-[]-({name: 'William Dafoe'}))
      RETURN n.full_name
 $$) as (full_name agtype);
 ```

--- a/docs/functions/scalar_functions.md
+++ b/docs/functions/scalar_functions.md
@@ -3,9 +3,9 @@
 
 ## id
 
-id() returns the id of a vertex or edge.
+`id()` returns the id of a vertex or edge.
 
-Syntax:`id(expression)`
+Syntax: `id(expression)`
 
 Returns:
 
@@ -82,7 +82,7 @@ Results
 
 ## start_id
 
-start_id() returns the id of the vertex that is the starting vertex for the edge.
+`start_id()` returns the id of the vertex that is the starting vertex for the edge.
 
 Syntax: `start_id(expression)`
 
@@ -161,7 +161,7 @@ Results
 
 ## end_id
 
-end_id() returns the id of the vertex that is the ending vertex for the edge.
+`end_id()` returns the id of the vertex that is the ending vertex for the edge.
 
 Syntax: `end_id(expression)`
 
@@ -238,7 +238,7 @@ Results
 
 ## type
 
-type() returns the string representation of the edge type
+`type()` returns the string representation of the edge type
 
 Syntax: `type(edge)`
 
@@ -340,7 +340,7 @@ Arguments:
 
 Considerations: 
 
-* properties(null) returns null.
+* `properties(null)` returns null.
 
 Query:
 
@@ -376,7 +376,7 @@ Results:
 
 ## head
 
-returns the first element in an agtype list.
+Returns the first element in an agtype list.
 
 Syntax: `head(list)`
 
@@ -411,8 +411,8 @@ Considerations:
 
 
 
-* head(null) returns null.
-* If the first element in the list is null, head(list) will return null.
+* `head(null)` returns null.
+* If the first element in the list is null, `head(list)` will return null.
 
 Query
 
@@ -455,9 +455,9 @@ Result:
 
 ## last
 
-returns the last element in an agtype list.
+Returns the last element in an agtype list.
 
-Syntax:`last(list)`
+Syntax: `last(list)`
 
 Returns:
 
@@ -490,8 +490,8 @@ Considerations:
 
 
 
-* tail(null) returns null.
-* If the last element in the list is null, last(list) will return null.
+* `last(null)` returns null.
+* If the last element in the list is null, `last(list)` will return null.
 
 Query
 
@@ -534,7 +534,7 @@ Result:
 
 ## length
 
-length() returns the length of a path.
+`length()` returns the length of a path.
 
 Syntax: `length(path)`
 
@@ -565,7 +565,7 @@ Arguments:
 </table>
 
 
-Considerations:length(null) returns null.
+Considerations: `length(null)` returns null.
 
 Query
 
@@ -580,7 +580,7 @@ $$) as (length_of_path agtype);
 ```
 
 
-The length of the path p is returned.
+The length of the path `p` is returned.
 
 Results:
 
@@ -612,9 +612,9 @@ Results:
 
 ## size
 
-size() returns the length of a list.
+`size()` returns the length of a list.
 
-Syntax:`size(list)`
+Syntax: `size(list)`
 
 Returns:
 
@@ -647,7 +647,7 @@ Considerations:
 
 
 
-* size(null) returns null.
+* `size(null)` returns null.
 
 Query
 
@@ -660,7 +660,7 @@ $$) as (size_of_list agtype);
 ```
 
 
-The length of the path p is returned.
+The length of the path `p` is returned.
 
 Results:
 
@@ -684,9 +684,9 @@ Results:
 
 ## startNode
 
-startNode() returns the start node of an edge.
+`startNode()` returns the start node of an edge.
 
-Syntax:`startNode(edge)`
+Syntax: `startNode(edge)`
 
 Returns:
 
@@ -719,7 +719,7 @@ Considerations:
 
 
 
-* startNode(null) returns null.
+* `startNode(null)` returns null.
 
 Query
 
@@ -759,7 +759,7 @@ Result
 
 ## endNode
 
-endNode() returns the start node of an edge.
+`endNode()` returns the start node of an edge.
 
 Syntax: `endNode(edge)`
 
@@ -794,7 +794,7 @@ Considerations:
 
 
 
-* endNode(null) returns null.
+* `endNode(null)` returns null.
 
 Query
 
@@ -834,9 +834,9 @@ Result
 
 ## timestamp
 
-timestamp() returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+`timestamp()` returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
 
-Syntax:`timestamp()`
+Syntax: `timestamp()`
 
 Returns:
 
@@ -850,7 +850,7 @@ Considerations:
 
 
 
-* timestamp() will return the same value during one entire query, even for long-running queries.
+* `timestamp()` will return the same value during one entire query, even for long-running queries.
 
 Query
 
@@ -887,7 +887,7 @@ Results:
 
 ## toBoolean
 
-toBoolean() converts a string value to a boolean value.
+`toBoolean()` converts a string value to a boolean value.
 
 Syntax: `toBoolean(expression)`
 
@@ -922,7 +922,7 @@ Considerations:
 
 
 
-* toBoolean(null) returns null.
+* `toBoolean(null)` returns null.
 * If expression is a boolean value, it will be returned unchanged.
 * If the parsing fails, null will be returned.
 
@@ -963,11 +963,11 @@ Result:
 
 ## toFloat
 
-toFloat() converts an integer or string value to a floating point number.
+`toFloat()` converts an integer or string value to a floating point number.
 
-Syntax:toFloat(expression)
+Syntax: `toFloat(expression)`
 
-Returns:A Float.
+Returns: A float.
 
 
 <table>
@@ -990,7 +990,7 @@ Considerations:
 
 
 
-* toFloat(null) returns null.
+* `toFloat(null)` returns null.
 * If expression is a floating point number, it will be returned unchanged.
 * If the parsing fails, null will be returned.
 
@@ -1031,7 +1031,7 @@ Result:
 
 ## toInteger
 
-toInteger() converts a floating point or string value to an integer value.
+`toInteger()` converts a floating point or string value to an integer value.
 
 Syntax:`toInteger(expression)`
 
@@ -1066,7 +1066,7 @@ Considerations:
 
 
 
-* toInteger(null) returns null.
+* `toInteger(null)` returns null.
 * If expression is an integer value, it will be returned unchanged.
 * If the parsing fails, null will be returned.
 
@@ -1107,9 +1107,9 @@ Result:
 
 ## coalesce
 
-coalesce() returns the first non-null value in the given list of expressions.
+`coalesce()` returns the first non-null value in the given list of expressions.
 
-Syntax:`coalesce(expression [, expression]*)`
+Syntax: `coalesce(expression [, expression]*)`
 
 Returns:
 

--- a/docs/functions/string_functions.md
+++ b/docs/functions/string_functions.md
@@ -3,9 +3,9 @@
 
 ## replace
 
-replace() returns a string in which all occurrences of a specified string in the original string have been replaced by another (specified) string.
+`replace()` returns a string in which all occurrences of a specified string in the original string have been replaced by another (specified) string.
 
-Syntax: **<code>replace(original, search, replace)</code></strong>
+Syntax: `replace(original, search, replace)`
 
 Returns:
 
@@ -93,7 +93,7 @@ Result:
 
 ## split
 
-split() returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
+`split()` returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
 
 Syntax: `split(original, split_delimiter)`
 
@@ -134,7 +134,7 @@ Considerations:
 
 
 
-* split(null, splitDelimiter) and split(original, null) both return null
+* `split(null, splitDelimiter)` and `split(original, null)` both return null
 
 Query:
 
@@ -169,7 +169,7 @@ Result:
 
 ## left
 
-left() returns a string containing the specified number of leftmost characters of the original string.
+`left()` returns a string containing the specified number of leftmost characters of the original string.
 
 Syntax: `left(original, length)`
 
@@ -210,10 +210,10 @@ Considerations:
 
 
 
-* left(null, length) and left(null, null) both return null
-* left(original, null) will raise an error.
-* If length is not a positive integer, an error is raised.
-* If length exceeds the size of original, original is returned.
+* `left(null, length)` and `left(null, null)` both return null
+* `left(original, null)` will raise an error.
+* If `length` is not a positive integer, an error is raised.
+* If `length` exceeds the size of `original`, `original` is returned.
 
 Query:
 
@@ -248,7 +248,7 @@ Result:
 
 ## right
 
-right() returns a string containing the specified number of rightmost characters of the original string.
+`right()` returns a string containing the specified number of rightmost characters of the original string.
 
 Syntax: `right(original, length)`
 
@@ -289,10 +289,10 @@ Considerations:
 
 
 
-* right(null, length) and right(null, null) both return null
-* right(original, null) will raise an error.
-* If length is not a positive integer, an error is raised.
-* If length exceeds the size of original, original is returned.
+* `right(null, length)` and `right(null, null)` both return null
+* `right(original, null)` will raise an error.
+* If `length` is not a positive integer, an error is raised.
+* If `length` exceeds the size of `original`, `original` is returned.
 
 Query:
 
@@ -327,9 +327,9 @@ Result:
 
 ## substring
 
-substring() returns a substring of the original string, beginning with a 0-based index start and length.
+`substring()` returns a substring of the original string, beginning with a 0-based index start and length.
 
-Syntax: <code>substring(original, <strong>start</strong> [, <strong>length</strong>])</code>
+Syntax: `substring(original, <strong>start</strong> [, <strong>length</strong>])`
 
 Returns:
 
@@ -374,12 +374,12 @@ Considerations:
 
 
 
-* start uses a zero-based index.
-* If length is omitted, the function returns the substring starting at the position given by start and extending to the end of original.
-* If original is null, null is returned.
-* If either start or length is null or a negative integer, an error is raised.
-* If start is 0, the substring will start at the beginning of original.
-* If length is 0, the empty string will be returned.
+* `start` uses a zero-based index.
+* If `length` is omitted, the function returns the substring starting at the position given by `start` and extending to the end of `original`.
+* If `original` is null, null is returned.
+* If either `start` or `length` is null or a negative integer, an error is raised.
+* If `start` is 0, the substring will start at the beginning of `original`.
+* If `length` is 0, the empty string will be returned.
 
 Query:
 
@@ -418,9 +418,9 @@ Result:
 
 ## rTrim
 
-rTrim() returns the original string with trailing whitespace removed.
+`rTrim()` returns the original string with trailing whitespace removed.
 
-Syntax: rTrim(original)
+Syntax: `rTrim(original)`
 
 Returns:
 
@@ -453,7 +453,7 @@ Considerations:
 
 
 
-* rTrim(null) returns null
+* `rTrim(null)` returns null
 
 Query:
 
@@ -488,7 +488,7 @@ Result:
 
 ## lTrim
 
-lTrim() returns the original string with trailing whitespace removed.
+`lTrim()` returns the original string with trailing whitespace removed.
 
 Syntax: `lTrim(original)`
 
@@ -523,7 +523,7 @@ Considerations:
 
 
 
-* lTrim(null) returns null
+* `lTrim(null)` returns null
 
 Query:
 
@@ -558,7 +558,7 @@ Result:
 
 ## trim
 
-trim() returns the original string with leading and trailing whitespace removed.
+`trim()` returns the original string with leading and trailing whitespace removed.
 
 Syntax: `trim(original)`
 
@@ -593,7 +593,7 @@ Considerations:
 
 
 
-* trim(null) returns null
+* `trim(null)` returns null
 
 Query:
 
@@ -628,7 +628,7 @@ Result:
 
 ## toLower
 
-toLower() returns the original string in lowercase.
+`toLower()` returns the original string in lowercase.
 
 Syntax: `toLower(original)`
 
@@ -663,7 +663,7 @@ Considerations:
 
 
 
-* toLower(null) returns null
+* `toLower(null)` returns null
 
 Query:
 
@@ -698,7 +698,7 @@ Result:
 
 ## toUpper
 
-toUpper() returns the original string in lowercase.
+`toUpper()` returns the original string in lowercase.
 
 Syntax: `toUpper(original)`
 
@@ -733,7 +733,7 @@ Considerations:
 
 
 
-* toUpper(null) returns null
+* `toUpper(null)` returns null.
 
 Query:
 
@@ -751,7 +751,7 @@ Result:
 
 <table>
   <tr>
-   <td><code>upper_str</code>
+   <td>`upper_str`
    </td>
   </tr>
   <tr>
@@ -768,7 +768,7 @@ Result:
 
 ## reverse
 
-reverse() returns a string in which the order of all characters in the original string have been reversed.
+`reverse()` returns a string in which the order of all characters in the original string have been reversed.
 
 Syntax: `reverse(original)`
 
@@ -803,7 +803,7 @@ Considerations:
 
 
 
-* reverse(null) returns null.
+* `reverse(null)` returns null.
 
 Query:
 
@@ -838,7 +838,7 @@ Result:
 
 ## toString
 
-toString() converts an integer, float or boolean value to a string.
+`toString()` converts an integer, float or boolean value to a string.
 
 Syntax:`toString(expression)`
 
@@ -873,7 +873,7 @@ Considerations:
 
 
 
-* toString(null) returns null
+* `toString(null)` returns null
 * If expression is a string, it will be returned unchanged.
 
 Query:

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -3,15 +3,15 @@
 
 ## degrees
 
-degrees() converts radians to degrees.
+`degrees()` converts radians to degrees.
 
-Syntax:`degrees(expression)`
+Syntax: `degrees(expression)`
 
 Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -38,7 +38,7 @@ Considerations:
 
 
 
-* degrees(null) returns null.
+* `degrees(null)` returns null.
 
 Query:
 
@@ -75,9 +75,9 @@ Results:
 
 ## radians
 
-radians() converts radians to degrees.
+`radians()` converts radians to degrees.
 
-Syntax:`radians(expression)`
+Syntax: `radians(expression)`
 
 Returns:
 
@@ -110,7 +110,7 @@ Considerations:
 
 
 
-* radians(null) returns null.
+* `radians(null)` returns null.
 
 Query:
 
@@ -147,7 +147,7 @@ Results:
 
 ## pi
 
-pi() returns the mathematical constant pi.
+`pi()` returns the mathematical constant pi.
 
 Syntax: `pi()`
 
@@ -194,15 +194,15 @@ Result:
 
 ## sin
 
-sin() returns the sine of a number.
+`sin()` returns the sine of a number.
 
-Syntax:`sin(expression)`
+Syntax: `sin(expression)`
 
 Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -229,7 +229,7 @@ Considerations:
 
 
 
-* sin(null) returns null.
+* `sin(null)` returns null.
 
 Query:
 
@@ -266,7 +266,7 @@ Results:
 
 ## cos
 
-cos() returns the cosine of a number.
+`cos()` returns the cosine of a number.
 
 Syntax: `cos(expression)`
 
@@ -274,7 +274,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -301,7 +301,7 @@ Considerations:
 
 
 
-* cos(null) returns null.
+* `cos(null)` returns null.
 
 Query:
 
@@ -338,7 +338,7 @@ Results:
 
 ## tan
 
-tan() returns the tangent of a number.
+`tan()` returns the tangent of a number.
 
 Syntax: `tan(expression)`
 
@@ -346,7 +346,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -373,7 +373,7 @@ Considerations:
 
 
 
-* tan(null) returns null.
+* `tan(null)` returns null.
 
 Query:
 
@@ -410,15 +410,15 @@ Results:
 
 ## asin
 
-asin() returns the arcsine of a number.
+`asin()` returns the arcsine of a number.
 
-Syntax:`asin(expression)`
+Syntax: `asin(expression)`
 
 Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -445,8 +445,8 @@ Considerations:
 
 
 
-* asin(null) returns null.
-* If (expression &lt; -1) or (expression > 1), then (asin(expression)) returns null.
+* `asin(null)` returns null.
+* If `expression < -1` or `expression > 1`, then `asin(expression)` returns null.
 
 Query:
 
@@ -483,15 +483,15 @@ Results:
 
 ## acos
 
-acos() returns the arccosine of a number.
+`acos()` returns the arccosine of a number.
 
-Syntax:`acos(expression)`
+Syntax: `acos(expression)`
 
 Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -518,8 +518,8 @@ Considerations:
 
 
 
-* acos(null) returns null.
-* If (expression &lt; -1) or (expression > 1), then (acos(expression)) returns null.
+* `acos(null)` returns null.
+* If `expression < -1` or `expression > 1`, then `acos(expression)` returns null.
 
 Query:
 
@@ -556,15 +556,15 @@ Results:
 
 ## atan
 
-atan() returns the arctangent of a number.
+`atan()` returns the arctangent of a number.
 
-Syntax:`atan(expression)`
+Syntax: `atan(expression)`
 
 Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -591,7 +591,7 @@ Considerations:
 
 
 
-* atan(null) returns null.
+* `atan(null)` returns null.
 
 Query:
 
@@ -628,7 +628,7 @@ Results:
 
 ## atan2
 
-atan2() returns the arctangent2 of a set of coordinates in radians.
+`atan2()` returns the arctangent2 of a set of coordinates in radians.
 
 Syntax: `atan2(expression1, expression2)`
 
@@ -636,7 +636,7 @@ Returns:
 
 
 ```
-A Float.
+A float.
 ```
 
 
@@ -669,7 +669,7 @@ Considerations:
 
 
 
-* atan2(null, null), atan2(null, expression2) and atan(expression1, null) all return null.
+* `atan2(null, null), atan2(null, expression2)` and `atan(expression1, null)` all return null.
 
 Query:
 

--- a/docs/functions/user_functions.md
+++ b/docs/functions/user_functions.md
@@ -1,6 +1,6 @@
 # User defined functions
 
-Users may add custom functions to the AGE. When using the Cypher function, all function calls with a Cypher query use the default namespace of: ag_catalog. However if a user want to use a function outside this namespace, they may do so by adding the namespace before the function name.
+Users may add custom functions to the AGE. When using the Cypher function, all function calls with a Cypher query use the default namespace of `ag_catalog`. However if a user want to use a function outside this namespace, they may do so by adding the namespace before the function name.
 
 Syntax: `namespace_name.function_name`
 


### PR DESCRIPTION
It's easier to identify the SQL clause sum() when formatted as an in-line code, `sum()`.

This PR formats all AGE code in the Functions section of the documentation to in-line codes.

Along with it are corrections to a few minor typographical errors.