### PR TITLE
In-line code formatting for the Introduction section

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,6 @@
+github:
+  homepage: https://age.apache.org
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -57,7 +57,7 @@ Results:
 
 # Using Cypher in a Join expression
 
-A Cypher query can be part of a JOIN clause.
+A Cypher query can be part of a `JOIN` clause.
 
 
 ```
@@ -127,7 +127,7 @@ Results:
 
 # Cypher in SQL expressions
 
-Cypher cannot be used in an expression, the query must exists in the FROM clause of a query. However, if the cypher query is placed in a Subquery, it will behave as any SQL style query.
+Cypher cannot be used in an expression, the query must exists in the `FROM` clause of a query. However, if the cypher query is placed in a subquery, it will behave as any SQL style query.
 
 
 ## Using Cypher with '='
@@ -174,7 +174,7 @@ Results:
 
 ## Working with Postgres's IN Clause
 
-When writing a cypher query that is known to return 1 column, but may have multiple rows. The IN operator may be used.
+When writing a cypher query that is known to return 1 column, but may have multiple rows. The `IN` operator may be used.
 
 Query:
 
@@ -228,7 +228,7 @@ Results:
 
 ## Working with Postgres EXISTS Clause
 
-When writing a cypher query that may have more than 1 column and row returned. The EXISTS operator may be used.
+When writing a cypher query that may have more than 1 column and row returned. The `EXISTS` operator may be used.
 
 Query:
 

--- a/docs/advanced/advanced_overview.md
+++ b/docs/advanced/advanced_overview.md
@@ -1,4 +1,4 @@
 # Overview
 
-All queries so far have followed the same pattern: a SELECT clause followed by a single Cypher call in the FROM clause. However, a Cypher query can be used in many other ways. This section highlights some more advanced ways of using the Cypher call within a more complex SQL/Cypher Hybrid Query.
+All queries so far have followed the same pattern: a `SELECT` clause followed by a single Cypher call in the `FROM` clause. However, a Cypher query can be used in many other ways. This section highlights some more advanced ways of using the Cypher call within a more complex SQL/Cypher Hybrid Query.
 

--- a/docs/advanced/prepared_statements.md
+++ b/docs/advanced/prepared_statements.md
@@ -6,12 +6,12 @@ Cypher can run a read query within a Prepared Statement. When using parameters w
 
 A cypher parameter is in the format of a '$' followed by an identifier. Unlike Postgres parameters, Cypher parameters start with a letter, followed by an alphanumeric string of arbitrary length.
 
-Example: <code>$<strong>parameter_name</strong></code>
+Example: `$parameter_name`
 
 
 ## Prepared Statements Preparation
 
-Preparing Prepared Statements in cypher is an extension of Postgres' stored procedure system. Use the PREPARE clause to create a query with the Cypher Function call in it. Do not place Postgres style parameters in the cypher query call, instead place Cypher parameters in the query and place a Postgres parameter as the third argument in the Cypher function call.
+Preparing Prepared Statements in cypher is an extension of Postgres' stored procedure system. Use the `PREPARE` clause to create a query with the Cypher Function call in it. Do not place Postgres style parameters in the cypher query call, instead place Cypher parameters in the query and place a Postgres parameter as the third argument in the Cypher function call.
 
 
 ```postgresql

--- a/docs/clauses/create.md
+++ b/docs/clauses/create.md
@@ -1,11 +1,11 @@
 # CREATE
 
-The CREATE clause is used to create graph vertices and edges. 
+The `CREATE` clause is used to create graph vertices and edges. 
 
 
 ## Terminal CREATE clauses
 
-A create clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `CREATE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 Query
 
@@ -275,7 +275,7 @@ Result
 
 
 ## Create a full path
-When you use CREATE and a pattern, all parts of the pattern that are not already in scope at this time will be created.
+When you use `CREATE` and a pattern, all parts of the pattern that are not already in scope at this time will be created.
 
 Query
 

--- a/docs/clauses/delete.md
+++ b/docs/clauses/delete.md
@@ -1,22 +1,22 @@
 # DELETE
 
-The DELETE clause is used to delete graph elements—nodes, relationships orpaths.
+The `DELETE` clause is used to delete graph elements—nodes, relationships orpaths.
 
 ## Terminal DELETE clauses
 
-A delete clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `DELETE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Introduction
 
-For removing properties, see REMOVE.
+For removing properties, see `REMOVE`.
 
-You cannot delete a node without also deleting edges that start or end on said vertex. Either explicitly delete the vertices,or use DETACH DELETE.
+You cannot delete a node without also deleting edges that start or end on said vertex. Either explicitly delete the vertices,or use `DETACH DELETE`.
 
 
 ## Delete isolated vertices
 
-To delete vertices with no edges associated with them, use the DELETE clause only.
+To delete a vertex, use the `DELETE` clause.
 
 Query
 
@@ -46,7 +46,7 @@ This will delete the vertices (with label Useless) that have no edges. Nothing i
 
 ## Delete all vertices and edges associated with them
 
-To delete all vertices (with label Useless) and the edges associated with them, use the DETACH option to first delete the vertice's edges then delete the vertex itself.
+Running a Match clause will collect all nodes, use the `DETACH` option to first delete a vertice's edges then delete the vertex itself.
 
 Query
 
@@ -76,7 +76,7 @@ Nothing is returned from this query.
 
 ## Delete edges only
 
-To delete an edge, use the match clause to find your edges, then add the variable to the DELETE.
+To delete an edge, use the match clause to find your edges, then add the variable to the `DELETE`.
 
 Query
 ```postgresql

--- a/docs/clauses/limit.md
+++ b/docs/clauses/limit.md
@@ -1,10 +1,10 @@
 # LIMIT
 
-LIMIT constrains the number of records in the output.
+`LIMIT` constrains the number of records in the output.
 
 ## Introduction
 
-LIMIT accepts any expression that evaluates to a positive integer.
+`LIMIT` accepts any expression that evaluates to a positive integer.
 
 
 ## Return a subset of the rows
@@ -54,7 +54,7 @@ Result
 
 ## Using an expression with LIMIT to return a subset of the rows
 
-Limit accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:
+`LIMIT` accepts any expression that evaluates to a positive integer as long as it is not referring to any external variables:
 
 Query
 

--- a/docs/clauses/match.md
+++ b/docs/clauses/match.md
@@ -1,12 +1,12 @@
 # MATCH
 
-The MATCH clause allows you to specify the patterns Cypher will search for in the database. This is the primary way of getting data into the current set of bindings. It is worth reading up more on the specification of the patterns themselves in Patterns.
+The `MATCH` clause allows you to specify the patterns Cypher will search for in the database. This is the primary way of getting data into the current set of bindings. It is worth reading up more on the specification of the patterns themselves in Patterns.
 
-MATCH is often coupled to a WHERE part which adds restrictions, or predicates, to the MATCH patterns, making them more specific. The predicates are part of the pattern description, and should not be considered a filter applied only after the matching is done. This means that WHERE should always be put together with the MATCH clause it belongs to.
+`MATCH` is often coupled to a `WHERE` part which adds restrictions, or predicates, to the `MATCH` patterns, making them more specific. The predicates are part of the pattern description, and should not be considered a filter applied only after the matching is done. This means that `WHERE` should always be put together with the `MATCH` clause it belongs to.
 
-MATCH can occur at the beginning of the query or later, possibly after a WITH. If it is the first clause, nothing will have been bound yet, and Cypher will design a search to find the results matching the clause and any associated predicates specified in any WHERE part. Vertices and edges found by this search are available as bound pattern elements, and can be used for pattern matching of sub-graphs. They can also be used in any future clauses, where Cypher will use the known elements, and from there find further unknown elements.
+MATCH can occur at the beginning of the query or later, possibly after a `WITH`. If it is the first clause, nothing will have been bound yet, and Cypher will design a search to find the results matching the clause and any associated predicates specified in any `WHERE` part. Vertices and edges found by this search are available as bound pattern elements, and can be used for pattern matching of sub-graphs. They can also be used in any future clauses, where Cypher will use the known elements, and from there find further unknown elements.
 
-Cypher is declarative, and so usually the query itself does not specify the algorithm to use to perform the search. Predicates in WHERE parts can be evaluated before pattern matching, during pattern matching, or after finding matches.
+Cypher is declarative, and so usually the query itself does not specify the algorithm to use to perform the search. Predicates in `WHERE` parts can be evaluated before pattern matching, during pattern matching, or after finding matches.
 
 
 ## Basic vertex finding
@@ -124,7 +124,7 @@ $$) as (title agtype);
 ```
 
 
-Returns all the movies directed by 'Oliver Stone'
+Returns all the movies directed by 'Oliver Stone'.
 
 
 <table>
@@ -159,7 +159,7 @@ $$) as (title agtype);
 ```
 
 
-Returns any vertices connected with the Person 'Oliver' that are labeled Movie.
+Returns any vertices connected with the `Person` 'Oliver' that are labeled `Movie`.
 
 
 <table>
@@ -184,7 +184,7 @@ Returns any vertices connected with the Person 'Oliver' that are labeled Movie.
 
 ### Outgoing Edges
 
-When the direction of an edge is of interest, it is shown by using `->` or &lt;-.
+When the direction of an edge is of interest, it is shown by using `->` or `<-`.
 
 Query
 
@@ -197,7 +197,7 @@ $$) as (title agtype);
 ```
 
 
-Returns any vertices connected with the Person'Oliver' by an outgoing edge.
+Returns any vertices connected with the `Person` 'Oliver' by an outgoing edge.
 
 
 <table>
@@ -267,7 +267,7 @@ $$) as (actors_name agtype);
 ```
 
 
-Returns all actors that ACTED_IN'Wall Street'.
+Returns all actors that `ACTED_IN` 'Wall Street'.
 
 
 <table>
@@ -310,7 +310,7 @@ $$) as (role agtype);
 ```
 
 
-Returns ACTED_IN roles for 'Wall Street'.
+Returns `ACTED_IN` roles for 'Wall Street'.
 
 
 <table>
@@ -394,7 +394,7 @@ Which describes a right directed path of three vertices and two edges can be rew
 (u)-[]->()-[]->(v)
 ```
 
-A range lengths can also be given:
+A range length can also be given:
 
 
 ```
@@ -409,26 +409,26 @@ Which is equivalent to:
 (u)-[]->()-[]->()-[]->()-[]->()-[]->(v)
 ```
 
-The previous example provided gave the edge both an lower and upper bound for the number of edges (and vertices) between u and v. Either one or both of these binding values can be excluded
+The previous example provided gave the edge both an lower and upper bound for the number of edges (and vertices) between `u` and `v`. Either one or both of these binding values can be excluded.
 
 
 ```
 (u)-[*3..]->(v)
 ```
 
-Returns all paths between u and v that have three or more edges included.
+Returns all paths between `u` and `v` that have three or more edges included.
 
 ```
 (u)-[*..5]->(v)
 ```
 
-Returns all paths between u and v that have 5 or fewer edges included.
+Returns all paths between `u` and `v` that have 5 or fewer edges included.
 
 ```
 (u)-[*]->(v)
 ```
 
-Returns all paths between u and v
+Returns all paths between `u` and `v`.
 
 
 ### Example
@@ -439,13 +439,13 @@ Query
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
-    MATCH p = (actor {name: 'Willam Defoe'})-[:ACTED_IN*2]-(co_actor)
+    MATCH p = (actor {name: 'Willam Dafoe'})-[:ACTED_IN*2]-(co_actor)
     RETURN relationships(p)
 $$) as (r agtype);
 ```
 
 
-Returns the list of edges, including the one that Willam Defoe acted in and the two spidermens he worked with.
+Returns the list of edges, including the one that Willam Dafoe acted in and the two Spiderman actors he worked with.
 
 
 <table>

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -1,13 +1,13 @@
 # MERGE
 
-The MERGE clause ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
+The `MERGE` clause ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
 
 
-MERGE either matches existing nodes, or creates new data. It’s a combination of MATCH and CREATE.
+`MERGE` either matches existing nodes, or creates new data. It’s a combination of `MATCH` and `CREATE`.
 
-For example, you can specify that the graph must contain a node for a user with a certain name. If there isn’t a node with the correct name, a new node will be created and its name property set. When using MERGE on full patterns, the behavior is that either the whole pattern matches, or the whole pattern is created. MERGE will not partially use existing patterns. If partial matches are needed, this can be accomplished by splitting a pattern up into multiple MERGE clauses.
+For example, you can specify that the graph must contain a node for a user with a certain name. If there isn’t a node with the correct name, a new node will be created and its name property set. When using `MERGE` on full patterns, the behavior is that either the whole pattern matches, or the whole pattern is created. `MERGE` will not partially use existing patterns. If partial matches are needed, this can be accomplished by splitting a pattern up into multiple `MERGE` clauses.
 
-As with MATCH, MERGE can match multiple occurrences of a pattern. If there are multiple matches, they will all be passed on to later stages of the query.
+As with `MATCH`, `MERGE` can match multiple occurrences of a pattern. If there are multiple matches, they will all be passed on to later stages of the query.
 
 ## Data Setup
 
@@ -101,7 +101,7 @@ RETURN michael.name, michael.bornIn
 $$) as (Name agtype, BornIn agtype);
 ```
 
-'Michael Douglas' will match the existing vertex and the vertex's name and BornIn properties are returned.
+'Michael Douglas' will match the existing vertex and the vertex's `name` and `bornIn` properties returned.
 
 <table>
   <tr>

--- a/docs/clauses/merge.md
+++ b/docs/clauses/merge.md
@@ -37,7 +37,7 @@ RETURN v
 $$) as (v agtype);
 ```
 
-If there exists a vertex with the label 'Critic' the vertex will be returns. If the vertex will be created and returned.
+If there exists a vertex with the label 'Critic' the vertex will be returns. Otherwise, the vertex will be created and returned.
 
 <table>
   <tr>
@@ -68,7 +68,7 @@ RETURN charlie
 $$) as (v agtype);
 ```
 
-If there exists a vertex with the label 'Critic' the vertex will be returns. If the vertex will be created and returned.
+If there exists a vertex with the label 'Critic' the vertex will be returns. Otherwise the vertex will be created and returned.
 
 <table>
   <tr>
@@ -85,7 +85,7 @@ If there exists a vertex with the label 'Critic' the vertex will be returns. If 
   </tr>
 </table>
 
-A new vertex with the name 'Charlie Sheen' will be created if not all properties exist with a single vertex. If a vertex does exist that will be returned instead.
+If a vertex with all the properties exist that will be returned. Otherwise, a new vertex with the name 'Charlie Sheen' will be created and returned.
 
 
 ### Merge a Single Vertex Specifying Both Label and Property

--- a/docs/clauses/order_by.md
+++ b/docs/clauses/order_by.md
@@ -181,7 +181,7 @@ Result
 
 ## Ordering null
 
-When sorting the result set, null will always come at the end of the result set for ascending sorting,and first when doing descending sort.
+When sorting the result set, null will always come at the end of the result set for ascending sorting, and first when doing descending sort.
 
 Query
 

--- a/docs/clauses/order_by.md
+++ b/docs/clauses/order_by.md
@@ -1,19 +1,19 @@
 # ORDER BY
 
-ORDER BY is a sub-clause following WITH, and it specifies that the output should be sorted and how. 
+`ORDER BY` is a sub-clause following `WITH`, and it specifies that the output should be sorted and how. 
 
 ## Introduction
 
-Note that you cannot sort on nodes or relationships, just on properties on these. ORDER BY relies on comparisons to sort the output, see Ordering and comparison of values.
+Note that you cannot sort on nodes or relationships, just on properties on these. `ORDER BY` relies on comparisons to sort the output, see Ordering and comparison of values.
 
-In terms of scope of variables, ORDER BY follows special rules, depending on if the projecting RETURN or WITH clause is either aggregating or DISTINCT. If it is an aggregating or DISTINCT projection, only the variables available in the projection are available. If the projection does not alter the output cardinality (which aggregation and DISTINCT do), variables available from before the projecting clause are also available. When the projection clause shadows already existing variables, only the new variables are available.
+In terms of scope of variables, `ORDER BY` follows special rules, depending on if the projecting `RETURN` or `WITH` clause is either aggregating or `DISTINCT`. If it is an aggregating or `DISTINCT` projection, only the variables available in the projection are available. If the projection does not alter the output cardinality (which aggregation and `DISTINCT` do), variables available from before the projecting clause are also available. When the projection clause shadows already existing variables, only the new variables are available.
 
-Lastly, it is not allowed to use aggregating expressions in the ORDER BY sub-clause if they are not also listed in the projecting clause. This last rule is to make sure that ORDER BY does not change the results, only the order of them.
+Lastly, it is not allowed to use aggregating expressions in the `ORDER BY` sub-clause if they are not also listed in the projecting clause. This last rule is to make sure that `ORDER BY` does not change the results, only the order of them.
 
 
 ## Order nodes by property
 
-ORDER BY is used to sort the output.
+`ORDER BY` is used to sort the output.
 
 Query
 
@@ -69,7 +69,7 @@ Result
 
 ## Order nodes by multiple properties
 
-You can order by multiple properties by stating each variable in the ORDER BY clause. Cypher will sort the result by the first variable listed, and for equal values, go to the next property in the ORDER BY clause, and so on.
+You can order by multiple properties by stating each variable in the `ORDER BY` clause. Cypher will sort the result by the first variable listed, and for equal values, go to the next property in the `ORDER BY` clause, and so on.
 
 Query
 
@@ -125,7 +125,7 @@ Result
 
 ## Order nodes in descending order
 
-By adding DESC[ENDING] after the variable to sort on, the sort will be done in reverse order.
+By adding `DESC[ENDING]` after the variable to sort on, the sort will be done in reverse order.
 
 Query
 

--- a/docs/clauses/remove.md
+++ b/docs/clauses/remove.md
@@ -1,16 +1,16 @@
 # REMOVE
 
-The REMOVE clause is used to remove properties from vertex and edges.
+The `REMOVE` clause is used to remove properties from vertex and edges.
 
 
 ## Terminal REMOVE clauses
 
-A remove clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `REMOVE` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Remove a property
 
-Cypher doesn’t allow storing null in properties. Instead, if no value exists, the property is just not there. So, to remove a property value on a node or a relationship, is also done with REMOVE.113
+Cypher doesn’t allow storing `null` in properties. Instead, if no value exists, the property is just not there. So, removing a property value on a node or a relationship is also done with `REMOVE`.
 
 Query
 

--- a/docs/clauses/return.md
+++ b/docs/clauses/return.md
@@ -1,11 +1,11 @@
 # RETURN  
 
-In the RETURN part of your query, you define which parts of the pattern you are interested in. It can be nodes, relationships, or properties on these.
+In the `RETURN` part of your query, you define which parts of the pattern you are interested in. It can be nodes, relationships, or properties on these.
 
 
 ## Return nodes
 
-To return a node, list it in the RETURN statement.
+To return a node, list it in the `RETURN` statement.
 
 Query
 
@@ -43,7 +43,7 @@ Result
 
 ## Return edges
 
-To return n edge, just include it in the RETURN list.
+To return `n`'s edges, just include it in the `RETURN` list.
 
 Query
 
@@ -117,7 +117,7 @@ Result
 
 ## Return all elements
 
-When you want to return all vertices, edges and paths found in a query, you can use the * symbol.
+When you want to return all vertices, edges and paths found in a query, you can use the `*` symbol.
 
 Query
 
@@ -163,7 +163,7 @@ Result
    </td>
   </tr>
   <tbody>
-   <td>(2 rows)
+   <td colspan="3">(2 rows)
    </td>
   </tr>
 </table>
@@ -335,7 +335,7 @@ Result
 
 ## Unique results
 
-DISTINCT retrieves only unique records depending on the fields that have been selected to output.
+`DISTINCT` retrieves only unique records depending on the fields that have been selected to output.
 
 Query
 

--- a/docs/clauses/set.md
+++ b/docs/clauses/set.md
@@ -1,16 +1,16 @@
 # SET
 
-The SET clause is used to update labels on nodes and properties on vertices and edges
+The `SET` clause is used to update labels on nodes and properties on vertices and edges
 
 
 ## Terminal SET clauses
 
-A set clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
+A `SET` clause that is not followed by another clause is called a terminal clause. When a cypher query ends with a terminal clause, no results will be returned from the cypher function call. However, the cypher function call still requires a column list definition. When cypher ends with a terminal node, define a single value in the column list definition: no data will be returned in this variable.
 
 
 ## Set a property
 
-To set a property on a node or relationship, use SET.
+To set a property on a node or relationship, use `SET`.
 
 Query
 
@@ -83,7 +83,7 @@ Result
 
 ## Remove a property
 
-Normally you remove a property by using REMOVE, but it’s sometimes handy to do it using the SET command. One example is if the property comes from a parameter.
+Normally you remove a property by using `REMOVE`, but it’s sometimes handy to do it using the `SET` command. One example is if the property comes from a parameter.
 
 Query
 

--- a/docs/clauses/skip.md
+++ b/docs/clauses/skip.md
@@ -1,10 +1,10 @@
 # SKIP
 
-SKIP defines from which record to start including the records in the output.
+`SKIP` defines from which record to start including the records in the output.
 
 ## Introduction
 
-By using SKIP, the result set will get trimmed from the top. Please note that no guarantees are made on the order of the result unless the query specifies the ORDER BY clause. SKIP accepts any expression that evaluates to a positive  integer.
+By using `SKIP`, the result set will get trimmed from the top. Please note that no guarantees are made on the order of the result unless the query specifies the `ORDER BY` clause. `SKIP` accepts any expression that evaluates to a positive  integer.
 
 ## Skip first three rows
 
@@ -92,7 +92,7 @@ Result
 
 ## Using an expression with SKIP to return a subset of the rows
 
-Using an expression with SKIP to return a subset of the rows
+Using an expression with `SKIP` to return a subset of the rows
 
 Query
 

--- a/docs/clauses/with.md
+++ b/docs/clauses/with.md
@@ -2,16 +2,16 @@
 
 ## Introduction
 
-Using WITH, you can manipulate the output before it is passed on to the following query parts. The manipulations can be of the shape and/or number of entries in the result set.
+Using `WITH`, you can manipulate the output before it is passed on to the following query parts. The manipulations can be of the shape and/or number of entries in the result set.
 
-WITH can also, like RETURN, alias expressions that are introduced into the results using the aliases as the binding name.
+`WITH` can also, like `RETURN`, alias expressions that are introduced into the results using the aliases as the binding name.
 
-WITH is also used to separate the reading of the graph from updating of the graph. Every part of a query must be either read-only or write-only. When going from a writing part to a reading part, the switch can be done with an optional WITH clause.
+`WITH` is also used to separate the reading of the graph from updating of the graph. Every part of a query must be either read-only or write-only. When going from a writing part to a reading part, the switch can be done with an optional `WITH` clause.
 
 
 ## Filter on aggregate function results
 
-Aggregated results have to pass through a WITH clause to be able to filter on.
+Aggregated results have to pass through a `WITH` clause to be able to filter on.
 
 Query
 ```postgresql
@@ -88,7 +88,7 @@ Result
 
 ## Limit branching of a path search
 
-You can match paths, limit to a certain number, and then match again using those paths as a base,as well as any number of similar limited searches.
+You can match paths, limit to a certain number, and then match again using those paths as a base, as well as any number of similar limited searches.
 
 Query
 
@@ -103,7 +103,7 @@ $$) as (name agtype);
 ```
 
 
-Starting at 'Anders', find all matching nodes, order by name descending and get the top result, thenfind all the nodes connected to that top result, and return their names.
+Starting at 'Anders', find all matching nodes, order by name descending and get the top result, then find all the nodes connected to that top result, and return their names.
 
 Result
 <table>

--- a/docs/functions/aggregate_functions.md
+++ b/docs/functions/aggregate_functions.md
@@ -62,7 +62,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* In a mixed set, any string value is always considered to be lower than any numeric value, and anylist is always considered to be lower than any string.
+* In a mixed set, any string value is always considered to be lower than any numeric value, and any list is always considered to be lower than any string.
 * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end.
 * min(null) returns null.
 
@@ -76,7 +76,7 @@ FROM cypher('graph_name', $$
     RETURN min(v.age)
 $$) as (min_age agtype);
 ```
-
+The lowest of all the values in the property age is returned.
 
 Result:
 
@@ -115,7 +115,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (result agtype);
 
 SELECT * FROM cypher('graph_name', $$ 
-    CREATE (:min_test {val:['a', 'b', 23]})
+    CREATE (:min_test {val:[1, 'b', 23]})
 $$) as (result agtype);
 ```
 
@@ -132,7 +132,7 @@ $$) as (min_val agtype);
 ```
 
 
-The lowest of all the values in the set—in this case, the list ['a', 'c', 23]—is returned, as (i) the two lists are considered to be lower values than the string "d", and (ii) the string "a" is considered tobe a lower value than the numerical value 1.
+The lowest of all the values in the set—in this case, the list ['a', 'b', 23]—is returned, as (i) the two lists are considered to be lower values than the string "d", and (ii) the string "a" is considered to be a lower value than the numerical value 1.
 
 Result:
 
@@ -192,7 +192,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* In a mixed set, any numeric value is always considered to be higher than any string value, and anystring value is always considered to be higher than any list.
+* In a mixed set, any numeric value is always considered to be higher than any string value, and any string value is always considered to be higher than any list.
 * Lists are compared in dictionary order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end.
 * max(null) returns null.
 
@@ -232,7 +232,7 @@ Result:
 
 ## stDev
 
-stDev() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N - 1 as the denominator, and should be used when taking a sample of the population for an unbiased estimate. When the standard variation of the entire population is being calculated, stdDevP should be used.
+stDev() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N - 1 as the denominator, and should be used when taking a sample of the population for an unbiased estimate. When the standard deviation of the entire population is being calculated, stDevP should be used.
 
 Syntax: `stDev(expression)`
 
@@ -268,7 +268,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* stDev(null) returns 0.
+* stDev(null) returns 0.0 (zero).
 
 Query
 
@@ -306,7 +306,7 @@ Result:
 
 ## stDevP
 
-stDevP() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N as the denominator, and should be used when calculating the standard deviation for an entire population. When the standard variation of only a sample of the population is being calculated, stDev should be used.
+stDevP() returns the standard deviation for the given value over a group. It uses a standard two-pass method, with N as the denominator, and should be used when calculating the standard deviation for an entire population. When the standard deviation of only a sample of the population is being calculated, stDev should be used.
 
 Syntax: `stDevP(expression)`
 
@@ -342,7 +342,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* stDevP(null) returns 0.
+* stDevP(null) returns 0.0 (zero).
 
 Query
 
@@ -460,7 +460,7 @@ Result:
 
 ## percentileDisc
 
-percentileDisc() returns the percentile of the given value over a group, with a percentile from 0.0to 1.0. It uses a rounding method and calculates the nearest value to the percentile. For interpolated values, see percentileCont.
+percentileDisc() returns the percentile of the given value over a group, with a percentile from 0.0 to 1.0. It uses a rounding method and calculates the nearest value to the percentile. For interpolated values, see percentileCont.
 
 Syntax: `percentileDisc(expression, percentile)`
 
@@ -527,7 +527,7 @@ Result:
    </td>
   </tr>
   <tr>
-   <td>33
+   <td>33.0
    </td>
   </tr>
   <tr>
@@ -579,8 +579,7 @@ Arguments:
 Considerations:
 * count(*) includes records returning null.
 * count(expr) ignores null values.
-* count(null) returns 0.
-* Using count(*) to return the number of nodes
+* count(null) returns 0 (zero).
 * count(*) can be used to return the number of nodes; for example, the number of nodes connected to some node n.
 
 
@@ -593,7 +592,7 @@ FROM cypher('graph_name', $$
 $$) as (age agtype, number_of_people agtype);
 ```
 
-The labels and age property of the start node n and the number of nodes related to n are returned.
+The age property of the start node n (with a name value of 'A') and the number of nodes related to n are returned.
 
 Result:
 <table>
@@ -616,7 +615,7 @@ Result:
 </table>
 
 
-Using count(*) to group and count relationship typescount(*) can be used to group relationship types and return the number.
+Using count(*) can be used to group and count relationship types, returning the number of relationships of each type.
 
 Query
 ```postgresql
@@ -628,7 +627,7 @@ $$) as (label agtype, count agtype);
 ```
 
 
-The relationship types and their group count are returned.
+The relationship type and the number of relationships with that type are returned.
 
 Result:
 
@@ -670,7 +669,7 @@ $$) as (count agtype);
 ```
 
 
-The number of nodes connected to the start node is returned.
+The number of nodes connected to the start node n is returned.
 
 Result:
 
@@ -708,7 +707,7 @@ $$) as (count agtype);
 ```
 
 
-The number of :Person nodes having an age property is returned.
+The number of nodes with the label Person that have a non-null value for the age property is returned.
 
 Result:
 
@@ -745,7 +744,7 @@ FROM cypher('graph_name', $$
 $$) as (friend_of_friends_distinct agtype, friend_of_friends agtype);
 ```
 
-Both B and C know D and thus D will get counted twice when not using DISTINCT
+Both B and C know D and thus D will get counted twice when not using DISTINCT.
 
 Result:
 <table>
@@ -880,7 +879,7 @@ Considerations:
 
 
 * Any null values are excluded from the calculation.
-* sum(null) returns 0.
+* sum(null) returns null.
 
 Query
 

--- a/docs/functions/list_functions.md
+++ b/docs/functions/list_functions.md
@@ -315,3 +315,42 @@ Result:
    </td>
   </tr>
 </table>
+
+## toBooleanList
+toBooleanList() converts a list of values and returns a list of boolean values. If any values are not convertible to boolean they will be null in the list returned.
+
+Syntax: `toBooleanList(list)`
+
+Returns:
+```
+An agtype list containing the converted elements; depending on the input value a converted value is either a boolean value or null.
+```
+
+Considerations:
+* Any null element in list is preserved.
+* Any boolean value in list is preserved.
+* If the list is null, null will be returned.
+* If the list is not a list, an error will be returned.
+
+Query:
+```sql
+SELECT * FROM cypher('expr', $$
+    RETURN toBooleanList(["true", "false", "true"])
+$$) AS (toBooleanList agtype);
+```
+
+Result:
+<table>
+  <tr>
+   <td>tobooleanlist
+   </td>
+  </tr>
+  <tr>
+   <td> [true, false, true]
+   </td>
+  </tr>
+  <tr>
+   <td colspan="3" >1 row
+   </td>
+  </tr>
+</table>

--- a/docs/functions/trigonometric_functions.md
+++ b/docs/functions/trigonometric_functions.md
@@ -408,6 +408,78 @@ Results:
 
 
 
+## Cot
+
+cot() returns the cotangent of a number.
+
+Syntax: `cot(expression)`
+
+Returns:
+
+
+```
+A Float.
+```
+
+
+Arguments:
+
+
+<table>
+  <tr>
+   <td>Name
+   </td>
+   <td>Description
+   </td>
+  </tr>
+  <tr>
+   <td>expression
+   </td>
+   <td>An agtype number expression that represents the angle in radians.
+   </td>
+  </tr>
+</table>
+
+
+Considerations:
+
+
+
+* cot(null) returns null.
+
+Query:
+
+
+```postgresql
+SELECT *
+FROM cypher('graph_name', $$
+    RETURN cot(0.5)
+$$) as (t agtype);
+```
+
+
+The cotangent of 0.5 is returned.
+
+Results:
+
+
+<table>
+  <tr>
+   <td>t
+   </td>
+  </tr>
+  <tr>
+   <td>1.830487721712452
+   </td>
+  </tr>
+  <tr>
+   <td>1 row(s) returned
+   </td>
+  </tr>
+</table>
+
+
+
 ## asin
 
 asin() returns the arcsine of a number.

--- a/docs/intro/aggregation.md
+++ b/docs/intro/aggregation.md
@@ -111,7 +111,7 @@ $$) as (distinct_eyes agtype, eyes agtype);
 
 ## Ambiguous Grouping Statements
 
-This feature of not requiring the user to specifiy their grouping keys for a query allows for ambiguity on what Cypher should qualify as their grouping keys. For more details [click here.](https://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/)
+This feature of not requiring the user to specify their grouping keys for a query allows for ambiguity on what Cypher should qualify as their grouping keys. For more details [click here.](https://opencypher.org/articles/2017/07/27/ocig1-aggregations-article/)
 
 Data Setup 
 ```postgresql

--- a/docs/intro/aggregation.md
+++ b/docs/intro/aggregation.md
@@ -3,9 +3,9 @@
 
 ## Introduction 
 
-Generally an aggregation aggr(expr) processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.md)).
+Generally an aggregation, `aggr(expr)`, processes all matching rows for each aggregation key found in an incoming record (keys are compared using [equivalence](../intro/comparability.md)).
 
-In a regular aggregation (i.e. of the form aggr(expr)), the list of aggregated values is the list of candidate values with all null values removed from it.
+In a regular aggregation (i.e. of the form `aggr(expr)`), the list of aggregated values is the list of candidate values with all null values removed from it.
 
 ## Data Setup
 
@@ -25,11 +25,11 @@ $$) as (a agtype);
 ```
 
 ## Auto Group By
-To calculate aggregated data, Cypher offers aggregation, analogous to SQL’s GROUP BY.
+To calculate aggregated data, Cypher offers aggregation, analogous to SQL’s `GROUP BY`.
 
-Aggregating functions take a  set of values and calculate An aggregated value over them. Examples are [avg()](../functions/aggregate_functions.md#avg) that calculates the average of multiple numeric values, or [min()](../functions/aggregate_functions.md#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression(such as n.age) to all the records within the same aggregation group.
+Aggregating functions take a  set of values and calculates an aggregated value over them. Examples are [`avg()`](../functions/aggregate_functions.md#avg) that calculates the average of multiple numeric values, or [`min()`](../functions/aggregate_functions.md#min) that finds the smallest numeric or string value in a set of values. When we say below that an aggregating function operates on a set of values, we mean these to be the result of the application of the inner expression (such as `n.age`) to all the records within the same aggregation group.
 
-Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the valuesgoing into the aggregate functions.
+Aggregation can be computed over all the matching subgraphs, or it can be further divided by introducing grouping keys. These are non-aggregate expressions, that are used to group the values going into the aggregate functions.
 
 Assume we have the following return statement:
 ```postgresql
@@ -41,8 +41,8 @@ $$) as (grouping_key agtype, count agtype);
 
 <table>
   <tr>
+   <td>grouping_key</td>
    <td>count</td>
-   <td>key</td>
   </tr>
   <tr>
    <td>"A"</td>
@@ -61,16 +61,16 @@ $$) as (grouping_key agtype, count agtype);
    <td>2</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(4 rows)</td>
   </tr>
 </table>
 
 
-We have two return expressions: grouping_key, and count(*). The first, grouping_key, is not an aggregate function, and so it will  be  the  grouping  key. The latter, count(*) is an aggregate expression. The matching subgraphs will be divided into different  buckets, depending on the grouping key. The aggregate function will then be run on these buckets, calculating an aggregate value per bucket. 
+We have two return expressions: `grouping_key`, and `count(*)`. The first, `grouping_key`, is not an aggregate function, and so it will  be  the  grouping  key. The latter, `count(*)` is an aggregate expression. The matching subgraphs will be divided into different  buckets, depending on the grouping key. The aggregate function will then be run on these buckets, calculating an aggregate value per bucket. 
 
 ## Sorting on aggregate functions
 
-To use aggregations to sort the result set, the aggregation must be included in the RETURN to be used in the ORDER BY.
+To use aggregations to sort the result set, the aggregation must be included in the `RETURN` to be used in the `ORDER BY`.
 
 ```postgresql
 SELECT *
@@ -82,10 +82,10 @@ $$) as (friends agtype, me agtype);
 ```
 
 ## Distinct aggregation
-In a distinct aggregation (i.e. of the form aggr(DISTINCT expr)), the list of aggregated values is the list of candidate values with all null values  removed from it. Furthermore, in a distinct aggregation, only one of all equivalent candidate values is included in the list of aggregated values, i.e. duplicates under equivalence are  removed. 
+In a distinct aggregation (i.e. of the form `aggr(DISTINCT expr)`), the list of aggregated values is the list of candidate values with all null values  removed from it. Furthermore, in a distinct aggregation, only one of all equivalent candidate values is included in the list of aggregated values, i.e. duplicates under equivalence are  removed. 
 
 
-The DISTINCT operator works in conjunction with aggregation. It is used to make all values unique before running them  through an aggregate function.
+The `DISTINCT` operator works in conjunction with aggregation. It is used to make all values unique before running them  through an aggregate function.
 
 ```postgresql
 SELECT *
@@ -105,7 +105,7 @@ $$) as (distinct_eyes agtype, eyes agtype);
    <td>3</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(1 row)</td>
   </tr>
 </table>
 
@@ -123,7 +123,7 @@ $$) as (a agtype);
 ```
 
 ### Invalid Query in AGE
-AGE's solution to this problem is to not allow a WITH or RETURN column to combine aggregate functions with variables that are not explicitly listed in another column of the same WITH or RETURN clause.
+AGE's solution to this problem is to not allow a `WITH` or `RETURN` column to combine aggregate functions with variables that are not explicitly listed in another column of the same `WITH` or `RETURN` clause.
 
 
 
@@ -143,7 +143,7 @@ LINE 3: RETURN x.a + count(*) + x.b + count(*) + x.c
 
 
 ### Valid Query in AGE
-Columns that do not include an aggregate function in AGE are considered to be the grouping keys for that WITH or RETURN clause. 
+Columns that do not include an aggregate function in AGE are considered to be the grouping keys for that `WITH` or `RETURN` clause. 
 
 For the above query, the user could rewrite the query is several ways that will return results
 
@@ -155,7 +155,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, key agtype);
 ```
 
-x.a + x.b + x.c is the grouping key. Grouping keys created like this must include parenthesis.
+`x.a + x.b + x.c` is the grouping key. Grouping keys created like this must include parenthesis.
 
 Results
 <table>
@@ -168,7 +168,7 @@ Results
    <td>6</td>
   </tr>
   <tr>
-   <td colspan="2">1 row</td>
+   <td colspan="2">(1 row)</td>
   </tr>
 </table>
 
@@ -182,7 +182,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, a agtype, b agtype, c agtype);
 ```
 
-x.a, x.b, and x.c will be considered different grouping keys
+`x.a`, `x.b`, and `x.c` will be considered different grouping keys
 
 Results:
 
@@ -214,13 +214,13 @@ Results:
    <td>3</td>
   </tr>
   <tr>
-   <td colspan="4">3 rows</td>
+   <td colspan="4">(3 rows)</td>
   </tr>
 </table>
 
 ### Vertices and edges in ambiguous grouping
 
-Alternatively, the grouping key can be a vertex or edge, and then any properties of the vertex or edge can be specified without being explicitly stated in a WITH or RETURN column.
+Alternatively, the grouping key can be a vertex or edge, and then any properties of the vertex or edge can be specified without being explicitly stated in a `WITH` or `RETURN` column.
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
@@ -229,7 +229,7 @@ SELECT * FROM cypher('graph_name', $$
 $$) as (count agtype, key agtype);
 ```
 
-Results will be grouped on x, because it is safe to assume that properties be considered unecessary for grouping to be unambiguous.
+Results will be grouped on `x`, because it is safe to assume that properties be considered unecessary for grouping to be unambiguous.
 
 Results
 <table>
@@ -252,14 +252,14 @@ Results
    <td>{"id": 1407374883553282, "label": "L", "properties": {"a": 2, "b": 3, "c": 1}}::vertex</td>
   </tr>
   <tr>
-   <td colspan="4">3 rows</td>
+   <td colspan="4">(3 rows)</td>
   </tr>
 </table>
 
 
 ### Hiding unwanted grouping keys
 
-If the grouping key is considered unecessary for the query output, the aggregation can be done in a WITH clause then passing information to the RETURN clause.
+If the grouping key is considered unecessary for the query output, the aggregation can be done in a `WITH` clause then passing information to the `RETURN` clause.
 
 ```postgresql
 SELECT * FROM cypher('graph_name', $$
@@ -286,7 +286,7 @@ Results
    <td>8</td>
   </tr>
   <tr>
-   <td colspan="1">3 rows</td>
+   <td colspan="1">(3 rows)</td>
   </tr>
 </table>
 

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -3,10 +3,10 @@ You can use the following instructions to create a graph from the files. This do
 - information about the current branch that includes the functions to load graphs from files
 - explanation of the functions that enable the creation of graphs from files 
 - the structure of CSV files that load functions as input, do and do not. 
-- A simple source code example to load countries and cities from the files. 
+- a simple source code example to load countries and cities from the files. 
 
 
-User can load graph in two steps 
+User can load a graph in two steps 
 - Load Vertices in the first step
 - Load Edges in the second step
 
@@ -16,6 +16,7 @@ User can load graph in two steps
 Following are the details about the functions to create vertices and edges from the file. 
 
 Function `load_labels_from_file` is used to load vertices from the CSV files. 
+Function `load_labels_from_file` is used to load vertices from the CSV files. 
 
 ```postgresql
 load_labels_from_file('<graph name>', 
@@ -23,7 +24,7 @@ load_labels_from_file('<graph name>',
                       '<file path>')
 ```
 
-By adding the fourth parameter user can exclude the id field. *** Use this when there is no id field in the file***
+By adding the fourth parameter user can exclude the id field. ***Use this when there is no id field in the file.***
 
 ```postgresql
 load_labels_from_file('<graph name>', 
@@ -50,7 +51,7 @@ Following is the explanation about the structure for CSV files for vertices and 
 | field name | Field description                                            |
 | ---------- | ------------------------------------------------------------ |
 | id         | it shall be the first column of the file and all values shall be a positive integer. <br>This is an optional field when `id_field_exists` is ***false***. <br>However, it should be present when `id_field_exists` is ***not*** set to false.  |
-| Properties | all other columns contains the properties for the nodes. <br>Header row shall contain the name of property |
+| properties | all other columns contains the properties for the nodes. <br>Header row shall contain the name of property |
 
 - Similarly, a CSV file for edges shall be formatted as follows 
 
@@ -62,11 +63,11 @@ Following is the explanation about the structure for CSV files for vertices and 
 | end_vertex_type   | Class of the node                                            |
 | properties        | properties of the edge. the header shall contain the property name |
 
-Example files can be viewed at `regress/age_load/data`
+Example files can be viewed at `regress/age_load/data`.
 
 ## Example SQL script 
 
-- Load and create graph 
+- Load and create graph.
 ```postgresql
 LOAD 'age';
 
@@ -74,7 +75,7 @@ SET search_path TO ag_catalog;
 SELECT create_graph('agload_test_graph');
 ```
 
-- Create label `Country` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `Country` and load vertices from csv file. ***Note this CSV file has id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','Country');
@@ -83,7 +84,7 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/countries.csv');
 ```
 
-- Create label `City` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `City` and load vertices from csv file. ***Note this CSV file has id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','City');
@@ -92,7 +93,7 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/cities.csv');
 ```
 
-- Create label `has_city` and load edges from csv file.
+- Create label `has_city` and load edges from CSV file.
 
 ```postgresql
 SELECT create_elabel('agload_test_graph','has_city');
@@ -100,7 +101,7 @@ SELECT load_edges_from_file('agload_test_graph', 'has_city',
      'age_load/data/edges.csv');
 ```
 
-- Check if the graph has been loaded properly
+- Check if the graph has been loaded properly.
 
 ```postgresql
 SELECT table_catalog, table_schema, table_name, table_type
@@ -117,7 +118,7 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
 
 ### Creating vertices without id field in the file. 
 
-- Create label `Country2` and load vertices from csv file. *** Note this CSV file has no id field ***
+- Create label `Country2` and load vertices from CSV file. ***Note this CSV file has no id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','Country2');
@@ -127,7 +128,8 @@ SELECT load_labels_from_file('agload_test_graph',
                              false);
 ```
 
-- Create label `City2` and load vertices from csv file. *** Note this CSV file has id field ***
+- Create label `City2` and load vertices from CSV file. ***Note this CSV file has id field.***
+
 ```postgresql
 SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph',
@@ -135,10 +137,12 @@ SELECT load_labels_from_file('agload_test_graph',
                              'age_load/data/cities.csv', 
                              false);
 ```
+
 - Check if the graph has been loaded properly and perform difference analysis between ids created automatically and picked from the files.
 
-- Labels `Country` and `City` were created with id field in the file
-- Labels `Country2` and `City2` were created with no id field in the file. 
+- Labels `Country` and `City` were created with id field in the file.
+- Labels `Country2` and `City2` were created with no id field in the file.
+
 ```postgresql
 SELECT COUNT(*) FROM agload_test_graph."Country2";
 SELECT COUNT(*) FROM agload_test_graph."City2";

--- a/docs/intro/agload.md
+++ b/docs/intro/agload.md
@@ -33,7 +33,7 @@ load_labels_from_file('<graph name>',
                       false)
 ```
 
-Function `load_edges_from_file` can be used to load properties from the CSV file. Please see the file structure in the following. 
+Function `load_edges_from_file` can be used to load edges from the CSV file. Please see the file structure in the following. 
 
 Note: make sure that ids in the edge file are identical to ones that are in vertices files. 
 
@@ -81,7 +81,7 @@ SELECT create_graph('agload_test_graph');
 SELECT create_vlabel('agload_test_graph','Country');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country',
-                             'age_load/data/countries.csv');
+                             'age/regress/age_load/data/countries.csv');
 ```
 
 - Create label `City` and load vertices from csv file. ***Note this CSV file has id field.***
@@ -90,7 +90,7 @@ SELECT load_labels_from_file('agload_test_graph',
 SELECT create_vlabel('agload_test_graph','City');
 SELECT load_labels_from_file('agload_test_graph',
                              'City', 
-                             'age_load/data/cities.csv');
+                             'age/regress/age_load/data/cities.csv');
 ```
 
 - Create label `has_city` and load edges from CSV file.
@@ -98,7 +98,7 @@ SELECT load_labels_from_file('agload_test_graph',
 ```postgresql
 SELECT create_elabel('agload_test_graph','has_city');
 SELECT load_edges_from_file('agload_test_graph', 'has_city',
-     'age_load/data/edges.csv');
+     'age/regress/age_load/data/edges.csv');
 ```
 
 - Check if the graph has been loaded properly.
@@ -124,17 +124,17 @@ SELECT COUNT(*) FROM cypher('agload_test_graph', $$MATCH (a)-[e]->(b) RETURN e$$
 SELECT create_vlabel('agload_test_graph','Country2');
 SELECT load_labels_from_file('agload_test_graph',
                              'Country2',
-                             'age_load/data/countries.csv', 
+                             'age/regress/age_load/data/countries.csv', 
                              false);
 ```
 
-- Create label `City2` and load vertices from CSV file. ***Note this CSV file has id field.***
+- Create label `City2` and load vertices from CSV file. ***Note this CSV file has no id field.***
 
 ```postgresql
 SELECT create_vlabel('agload_test_graph','City2');
 SELECT load_labels_from_file('agload_test_graph',
                              'City2',
-                             'age_load/data/cities.csv', 
+                             'age/regress/age_load/data/cities.csv', 
                              false);
 ```
 

--- a/docs/intro/comparability.md
+++ b/docs/intro/comparability.md
@@ -1,17 +1,17 @@
 # Comparability, Equality, Orderability and Equivalence
 
-AGE already has good semantics for equality within the primitive types (booleans, strings,integers, and floats) and maps. Furthermore, Cypher has good semantics for comparability and orderability for integers, floats, and strings, within each of the types. However, working with values of different types deviates from Postgres’ defined logic and the openCypher specification:
+AGE already has good semantics for equality within the primitive types (booleans, strings, integers, and floats) and maps. Furthermore, Cypher has good semantics for comparability and orderability for integers, floats, and strings, within each of the types. However, working with values of different types deviates from Postgres’ defined logic and the openCypher specification:
 
 
 
-* Comparability between values of different types is defined. This deviation is particularly pronounced when it occurs as part of the evaluation of predicates (in WHERE).
-* ORDER BY will not fail if the values passed to it have different types.
+* Comparability between values of different types is defined. This deviation is particularly pronounced when it occurs as part of the evaluation of predicates (in `WHERE`).
+* `ORDER BY` will not fail if the values passed to it have different types.
 
-The underlying conceptual model is complex and sometimes inconsistent. This leads to an unclear relationship between comparison operators, equality, grouping, and ORDER BY:
+The underlying conceptual model is complex and sometimes inconsistent. This leads to an unclear relationship between comparison operators, equality, grouping, and `ORDER BY`:
 * Comparability and orderability are aligned with each other consistently, as all types can be ordered and compared.
-* The difference between equality and equivalence, as exposed by IN, =, DISTINCT, and grouping, in AGE is limited to testing two instances of the value null to each other
-    * In equality, null = null is null.
-    * In equivalence, used by DISTINCT and when grouping values, two null values are always treated as being the same value.
+* The difference between equality and equivalence, as exposed by `IN`, `=`, `DISTINCT`, and grouping, in AGE is limited to testing two instances of the value `null` to each other.
+    * In equality, `null = null` is `null`.
+    * In equivalence, used by `DISTINCT` and when grouping values, two null values are always treated as being the same value.
     * However, equality treats null values differently if they are an element of a list or a map value.
 
 ## Concepts
@@ -31,12 +31,12 @@ Equality is used by the equality operators (=, &lt;>), and the list membership o
 
 ### Orderability
 
-Orderability is used by the ORDER BY clause, and defines the underlying semantics of how to order values.
+Orderability is used by the `ORDER BY` clause, and defines the underlying semantics of how to order values.
 
 
 ### Equivalence
 
-Equivalence is used by the DISTINCT modifier and by grouping in projection clauses (WITH,RETURN), and defines the underlying semantics to determine if two values are the same in these contexts.
+Equivalence is used by the `DISTINCT` modifier and by grouping in projection clauses (`WITH`, `RETURN`), and defines the underlying semantics to determine if two values are the same in these contexts.
 
 ## Comparability and equality
 
@@ -57,23 +57,23 @@ Comparability is defined between any pair of values, as specified below.
         * Integers are compared numerically in ascending order.
     * Floats
         * Floats (excluding NaN values and the Infinities) are compared numerically in ascending order.
-        * Positive infinity is of type FLOAT, equal to itself and greater than any other number, except NaN values.
-        * Negative infinity is of type FLOAT, equal to itself and less than any other number.
+        * Positive infinity is of type `FLOAT`, equal to itself and greater than any other number, except NaN values.
+        * Negative infinity is of type `FLOAT`, equal to itself and less than any other number.
         * NaN values are comparable to each and greater than any other float value.
     * Numeric
         * Numerics are compared numerically in ascending order.
 * Booleans
-    * Booleans are compared such that false is less than true.
+    * Booleans are compared such that `false` is less than `true`.
     * Comparison to any value that is not also a boolean follows the rules of orderability.
 * Strings
-    * Strings are compared in dictionary order, i.e. characters are compared pairwise in ascending order from the start of the string to the end. Characters missing in a shorter string are considered to be less than any other character. For example, 'a' &lt; 'aa'.
+    * Strings are compared in dictionary order, i.e. characters are compared pairwise in ascending order from the start of the string to the end. Characters missing in a shorter string are considered to be less than any other character. For example, `'a' < 'aa'`.
     * Comparison to any value that is not also a string follows the rules of orderability.
 * Lists
-    * Lists are compared in sequential order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including null values). For example, [1] &lt; [1, 0]but also [1] &lt; [1, null].
+    * Lists are compared in sequential order, i.e. list elements are compared pairwise in ascending order from the start of the list to the end. Elements missing in a shorter list are considered to be less than any other value (including null values). For example, `[1] < [1, 0]`, but also `[1] < [1, null]`.
     * Comparison to any value that is not also a list follows the rules of orderability.
 * Maps
     * The comparison order for maps is unspecified and left to implementations.
-    * The comparison order for maps must align with the equality semantics outlined below. In consequence, any map that contains an entry that maps its key to a null value is incomparable. For example, {a: 1} &lt;= {a: 1, b: null} evaluates to null.
+    * The comparison order for maps must align with the equality semantics outlined below. In consequence, any map that contains an entry that maps its key to a null value is incomparable. For example, `{a: 1} <= {a: 1, b: null}` evaluates to `null`.
     * Comparison to any value that is not also a regular map follows the rules of orderability.
 
 Entities
@@ -82,7 +82,7 @@ Entities
 * Edges
     * The comparison order for edges is based on the assigned graphid.
 * Paths
-    * Paths are compared as if they were a list of alternating nodes and relationships of the path from the start node to the end node. For example, given nodes n1, n2, n3, and relationships r1and r2, and given that n1 &lt; n2 &lt; n3 and r1 &lt; r2, then the path p1 from n1 to n3 via r1 would be less than the path p2 to n1 from n2 via r2. 
+    * Paths are compared as if they were a list of alternating nodes and relationships of the path from the start node to the end node. For example, given nodes n1, n2, n3, and relationships r1 and r2, and given that n1 &lt; n2 &lt; n3 and r1 &lt; r2, then the path p1 from n1 to n3 via r1 would be less than the path p2 to n1 from n2 via r2. 
     * Expressed in terms of lists: 
 ```
 p1 < p2
@@ -95,7 +95,7 @@ p1 < p2
 ```
     * Comparison to any value that is not also a path will return false.
 * NULL
-    * null is incomparable with any other value (including other null values.)
+    * `null` is incomparable with any other value (including other null values.)
 
 
 ## Orderability Between different Agtypes

--- a/docs/intro/cypher.md
+++ b/docs/intro/cypher.md
@@ -1,6 +1,6 @@
 # The AGE Cypher Query Format
 
-Cypher queries are constructed using a function called cypher in ag_catalog which returns a Postgres SETOF [records](https://www.postgresql.org/docs/11/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET).
+Cypher queries are constructed using a function called cypher in `ag_catalog` which returns a Postgres `SETOF` [records](https://www.postgresql.org/docs/11/xfunc-sql.html#XFUNC-SQL-FUNCTIONS-RETURNING-SET).
 
 
 ## Cypher()
@@ -68,7 +68,7 @@ Cypher may not be used as part of an expression, use a subquery instead. See [Ad
 
 ## SELECT Clause
 
-Calling Cypher in the SELECT clause as an independent column is not allowed. However Cypher may be used when it belongs as a conditional. 
+Calling Cypher in the `SELECT` clause as an independent column is not allowed. However Cypher may be used when it belongs as a conditional. 
 
 Not Allowed:
 

--- a/docs/intro/graphs.md
+++ b/docs/intro/graphs.md
@@ -5,7 +5,7 @@ A graph consists of a set of vertices and edges, where each individual node and 
 
 ## Create a Graph
 
-To create a graph, use the create_graph function, located in the ag_catalog namespace.
+To create a graph, use the `create_graph` function, located in the `ag_catalog` namespace.
 
 
 ### create_graph()
@@ -52,7 +52,7 @@ SELECT * FROM ag_catalog.create_graph('graph_name');
 
 ## Delete a Graph
 
-To delete a graph, use the drop_graph function, located in the ag_catalog namespace.
+To delete a graph, use the `drop_graph` function, located in the `ag_catalog` namespace.
 
 
 ### drop_graph()

--- a/docs/intro/setup.md
+++ b/docs/intro/setup.md
@@ -64,9 +64,9 @@ sudo apt install postgresql-xx postgresql-server-dev-all
 
 Clone the <a href='https://github.com/apache/age'>github repository</a> or <a href='https://github.com/apache/age/releases'>download an official release</a>
 
-Run the pg_config utility and check the version of PostgreSQL. Apache AGE supports all the stable versions of postgresql(11, 12, 13, 14 and 15).
+Run the pg_config utility and check the version of PostgreSQL. Apache AGE supports all the stable versions of PostgreSQL (11, 12, 13, 14 and 15).
 
-The build process will attempt to use the first path in the PATH environment variable when installing AGE. If the pg_config path is located there, run the following command in the source code directory of Apache AGE to build and install the extension.
+The build process will attempt to use the first path in the PATH environment variable when installing AGE. If the `PG_CONFIG` path is located there, run the following command in the source code directory of Apache AGE to build and install the extension.
 
 ```console
 make install
@@ -81,7 +81,7 @@ make PG_CONFIG=/path/to/postgres/bin/pg_config install
 ### Post Installation AGE Setup
 
 
-After the installation, open a connection to a running instance of your database and run the CREATE EXTENSION command to have AGE installed on the server.
+After the installation, open a connection to a running instance of your database and run the `CREATE EXTENSION` command to have AGE installed on the server.
 
 ```postgresql
 CREATE EXTENSION age;
@@ -126,7 +126,7 @@ For every connection of AGE you start you will need to load the AGE extension.
 LOAD 'age';
 ```
 
-We recommend adding ag_catalog to your search_path to simplify your queries. The rest of this document will assume you have done so. If you do not, remember to add 'ag_catalog' to your cypher query function calls.
+We recommend adding `ag_catalog` to your search_path to simplify your queries. The rest of this document will assume you have done so. If you do not, remember to add `ag_catalog` to your cypher query function calls.
 
 ```postgresql
 SET search_path = ag_catalog, "$user", public;
@@ -134,7 +134,7 @@ SET search_path = ag_catalog, "$user", public;
 
 ### Allow non-superusers to use Apache AGE
 
-* Non-superusers can only apply LOAD to library files located in `$libdir/plugins/` (see <https://www.postgresql.org/docs/15/sql-load.html>). A symlink can be created to allow non-superusers to LOAD the Apache AGE library:
+* Non-superusers can only apply `LOAD` to library files located in `$libdir/plugins/` (see <https://www.postgresql.org/docs/15/sql-load.html>). A symlink can be created to allow non-superusers to `LOAD` the Apache AGE library:
 
 ```console
 sudo ln -s /usr/lib/postgresql/15/lib/age.so /usr/lib/postgresql/15/lib/plugins/age.so

--- a/docs/intro/types.md
+++ b/docs/intro/types.md
@@ -1,6 +1,6 @@
 # Data Types - An Introduction to agtype
 
-AGE uses a custom data type called agtype, which is the only data type returned by AGE. Agtype is a superset of Json and a custom implementation of JsonB.
+AGE uses a custom data type called `agtype`, which is the only data type returned by AGE. `agtype` is a superset of Json and a custom implementation of JsonB.
 
 
 ## Simple Data Types
@@ -8,7 +8,7 @@ AGE uses a custom data type called agtype, which is the only data type returned 
 
 ### Null
 
-In Cypher, null is used to represent missing or undefined values. Conceptually, null means 'a missing unknown value' and it is treated somewhat differently from other values. For example getting a property from a vertex that does not have said property produces null. Most expressions that take null as input will produce null. This includes boolean expressions that are used as predicates in the WHERE clause. In this case, anything that is not true is interpreted as being false. null is not equal to null. Not knowing two values does not imply that they are the same value. So the expression null = null yields null and not true.
+In Cypher, `null` is used to represent missing or undefined values. Conceptually, `null` means 'a missing unknown value', and it is treated somewhat differently from other values. For example getting a property from a vertex that does not have said property produces `null`. Most expressions that take `null` as input will produce `null`. This includes boolean expressions that are used as predicates in the `WHERE` clause. In this case, anything that is not true is interpreted as being false. `null` is not equal to `null`. Not knowing two values does not imply that they are the same value. So the expression `null = null` yields `null` and not `true`.
 
 Input/Output Format
 
@@ -23,7 +23,7 @@ $$) AS (null_result agtype);
 ```
 
 
-A null will appear as an empty space.
+A `null` will appear as an empty space.
 
 Result:
 
@@ -48,7 +48,7 @@ Result:
 
 #### Agtype NULL vs Postgres NULL
 
-The concept of NULL in Agtype and Postgres is the same as it is in Cypher.
+The concept of `NULL` in `agtype` and Postgres is the same as it is in Cypher.
 
 ### Integer
 
@@ -106,9 +106,9 @@ Inexact means that some values cannot be converted exactly to the internal forma
 Values that are too large or too small will cause an error. Rounding might take place if the precision of an input number is too high. Numbers too close to zero that are not representable as distinct from zero will cause an underflow error.
 
 In addition to ordinary numeric values, the floating-point types have several special values:
-* Infinity
-* -Infinity
-* NaN
+* `Infinity`
+* `-Infinity`
+* `NaN`
 
 These represent the IEEE 754 special values “infinity”, “negative infinity”, and “not-a-number”, respectively. When writing these values as constants in a Cypher command, you must put quotes around them and typecast them, for example 
 ```
@@ -173,9 +173,9 @@ The maximum allowed precision when explicitly specified in the type declaration 
 
 If the scale of a value to be stored is greater than the declared scale of the column, the system will round the value to the specified number of fractional digits. Then, if the number of digits to the left of the decimal point exceeds the declared precision minus the declared scale, an error is raised.
 
-Numeric values are physically stored without any extra leading or trailing zeroes. Thus, the declared precision and scale of a column are maximums, not fixed allocations. (In this sense the numeric type is more akin to varchar(_n_) than to char(_n_).) The actual storage requirement is two bytes for each group of four decimal digits, plus three to eight bytes overhead.
+Numeric values are physically stored without any extra leading or trailing zeroes. Thus, the declared precision and scale of a column are maximums, not fixed allocations. (In this sense the numeric type is more akin to `varchar(n)` than to `char(n)`.) The actual storage requirement is two bytes for each group of four decimal digits, plus three to eight bytes overhead.
 
-In addition to ordinary numeric values, the numeric type allows the special value NaN, meaning “not-a-number”. Any operation on NaN yields another NaN. When writing this value as a constant in an SQL command, you must put quotes around it, for example UPDATE table SET x = 'NaN'. 
+In addition to ordinary numeric values, the numeric type allows the special value `NaN`, meaning “not-a-number”. Any operation on `NaN` yields another `NaN`. When writing this value as a constant in an SQL command, you must put quotes around it, for example `UPDATE table SET x = 'NaN'`. 
 
 
 
@@ -189,7 +189,7 @@ When rounding values, the numeric type rounds ties away from zero, while (on mos
 
 Input/Output Format:
 
-When creating a numeric data type, the ‘::numeric’ data annotation is required.
+When creating a numeric data type, the `::numeric` data annotation is required.
 
 Query
 
@@ -224,9 +224,9 @@ Result:
 
 #### Bool 
 
-AGE provides the standard Cypher type boolean. The boolean type can have several states: “true”, “false”, and a third state, “unknown”, which is represented by the Agtype null value.
+AGE provides the standard Cypher type `boolean`. The `boolean` type can have several states: “true”, “false”, and a third state, “unknown”, which is represented by the Agtype `null` value.
 
-Boolean constants can be represented in Cypher queries by the keywords TRUE, FALSE, and NULL.
+Boolean constants can be represented in Cypher queries by the keywords `TRUE`, `FALSE`, and `NULL`.
 
 Input/Output Format
 
@@ -241,7 +241,7 @@ $$) AS (boolean_result agtype);
 ```
 
 
-Unlike Postgres, AGE’s boolean outputs as the full word, ie. true and false as opposed to t and f.
+Unlike Postgres, AGE’s boolean outputs as the full word, ie. `true` and `false` as opposed to `t` and `f`.
 
 Result:
 
@@ -372,7 +372,7 @@ Result:
 
 ### List
 
-All examples will use the [WITH](../clauses/with.md) clause and [RETURN](../clauses/return.md) clause.
+All examples will use the [`WITH`](../clauses/with.md) clause and [`RETURN`](../clauses/return.md) clause.
 
 
 #### Lists in general
@@ -413,7 +413,7 @@ Result:
 
 #### NULL in a List
 
-A list can hold the value null, unlike when a null is an independent value, it will appear as the word ‘null’ in a list
+A list can hold the value `null`, and unlike when a null is an independent value, it will appear as the word ‘null’ in a list
 
 Query
 
@@ -724,7 +724,7 @@ Result:
 </table>
 
 
-Out-of-bound slices are simply truncated, but out-of-bound single elements return null.
+Out-of-bound slices are simply truncated, but out-of-bound single elements return `null`.
 
 Query
 
@@ -955,7 +955,7 @@ A label is an identifier that classifies vertices and edges into certain categor
 * Edges are required to have a label, but vertices do not. 
 * The names of labels between vertices and edges cannot overlap. 
 
-See [CREATE](../clauses/create.md) clause for information about how to make entities with labels.
+See [`CREATE`](../clauses/create.md) clause for information about how to make entities with labels.
 
 
 ### Properties

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docutils==0.17.1
 idna==3.4
 imagesize==1.4.1
 Jinja2==3.1.2
-markdown-it-py==2.1.0
+markdown-it-py==2.2.0
 MarkupSafe==2.1.1
 mdit-py-plugins==0.3.1
 mdurl==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ mdurl==0.1.2
 myst-parser==0.18.1
 packaging==21.3
 pydantic==1.10.2
-Pygments==2.13.0
+Pygments==2.15.0
 pyparsing==3.0.9
 pytz==2022.4
 PyYAML==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.12
 Babel==2.10.3
-certifi==2022.9.24
+certifi==2023.7.22
 charset-normalizer==2.1.1
 click==8.1.3
 colorama==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ Pygments==2.15.0
 pyparsing==3.0.9
 pytz==2022.4
 PyYAML==6.0
-requests==2.28.1
+requests==2.31.0
 rich==12.6.0
 rstcheck==6.1.0
 rstcheck-core==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ sphinxcontrib-serializinghtml==1.1.5
 typer==0.6.1
 types-docutils==0.18.3
 typing_extensions==4.3.0
-urllib3==1.26.12
+urllib3==1.26.17


### PR DESCRIPTION
It's easier to identify the SQL clause WHERE when written as an in-line code, `WHERE`.

This PR updates all SQL commands, Cypher commands, AGE and PostgreSQL data types in the Introduction section of the documentation to in-line codes.

Along with it are corrections to a few minor typographical errors.