### PR TITLE
In-line code formatting for SQL clauses in the Advanced Section

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -57,7 +57,7 @@ Results:
 
 # Using Cypher in a Join expression
 
-A Cypher query can be part of a JOIN clause.
+A Cypher query can be part of a `JOIN` clause.
 
 
 ```
@@ -127,7 +127,7 @@ Results:
 
 # Cypher in SQL expressions
 
-Cypher cannot be used in an expression, the query must exists in the FROM clause of a query. However, if the cypher query is placed in a Subquery, it will behave as any SQL style query.
+Cypher cannot be used in an expression, the query must exists in the `FROM` clause of a query. However, if the cypher query is placed in a subquery, it will behave as any SQL style query.
 
 
 ## Using Cypher with '='
@@ -174,7 +174,7 @@ Results:
 
 ## Working with Postgres's IN Clause
 
-When writing a cypher query that is known to return 1 column, but may have multiple rows. The IN operator may be used.
+When writing a cypher query that is known to return 1 column, but may have multiple rows. The `IN` operator may be used.
 
 Query:
 
@@ -228,7 +228,7 @@ Results:
 
 ## Working with Postgres EXISTS Clause
 
-When writing a cypher query that may have more than 1 column and row returned. The EXISTS operator may be used.
+When writing a cypher query that may have more than 1 column and row returned. The `EXISTS` operator may be used.
 
 Query:
 

--- a/docs/advanced/advanced_overview.md
+++ b/docs/advanced/advanced_overview.md
@@ -1,4 +1,4 @@
 # Overview
 
-All queries so far have followed the same pattern: a SELECT clause followed by a single Cypher call in the FROM clause. However, a Cypher query can be used in many other ways. This section highlights some more advanced ways of using the Cypher call within a more complex SQL/Cypher Hybrid Query.
+All queries so far have followed the same pattern: a `SELECT` clause followed by a single Cypher call in the `FROM` clause. However, a Cypher query can be used in many other ways. This section highlights some more advanced ways of using the Cypher call within a more complex SQL/Cypher Hybrid Query.
 

--- a/docs/advanced/prepared_statements.md
+++ b/docs/advanced/prepared_statements.md
@@ -6,12 +6,12 @@ Cypher can run a read query within a Prepared Statement. When using parameters w
 
 A cypher parameter is in the format of a '$' followed by an identifier. Unlike Postgres parameters, Cypher parameters start with a letter, followed by an alphanumeric string of arbitrary length.
 
-Example: <code>$<strong>parameter_name</strong></code>
+Example: `$parameter_name`
 
 
 ## Prepared Statements Preparation
 
-Preparing Prepared Statements in cypher is an extension of Postgres' stored procedure system. Use the PREPARE clause to create a query with the Cypher Function call in it. Do not place Postgres style parameters in the cypher query call, instead place Cypher parameters in the query and place a Postgres parameter as the third argument in the Cypher function call.
+Preparing Prepared Statements in cypher is an extension of Postgres' stored procedure system. Use the `PREPARE` clause to create a query with the Cypher Function call in it. Do not place Postgres style parameters in the cypher query call, instead place Cypher parameters in the query and place a Postgres parameter as the third argument in the Cypher function call.
 
 
 ```postgresql


### PR DESCRIPTION
It's easier to identify the SQL clause WHERE when formatted as an in-line code, `WHERE`.

This PR formats all SQL clauses in the Advanced section of the documentation to in-line codes.