### PR TITLE
Fix join example in advanced.md

### DIFF
--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -287,7 +287,7 @@ SELECT graph_1.name, graph_1.age, graph_2.license_number
 FROM cypher('graph_1', $$
     MATCH (v:Person)
     RETURN v.name, v.age
-$$) as graph_1(col_1 agtype, col_2 agtype, col_3 agtype)
+$$) as graph_1(name agtype, age agtype)
 JOIN cypher('graph_2', $$
     MATCH (v:Doctor)
     RETURN v.name, v.license_number


### PR DESCRIPTION
The AS-clause has a mismatch in number of returned rows and their names (as used by the join condition).