### PR TITLE
Make clean usage for Prepared Statements (clone pr#105)

### DIFF
--- a/docs/advanced/prepared_statements.md
+++ b/docs/advanced/prepared_statements.md
@@ -29,8 +29,9 @@ AS (v agtype);
 
 When executing the prepared statement, place an agtype map with the parameter values where the Postgres Parameter in the Cypher function call is. The value must be an agtype map or an error will be thrown. Exclude the `'$'` for parameter names.
 
+The name of the prepared statement in the EXECUTE must be the same as the one in the PREPARE command.
 
 ```postgresql
-EXECUTE cypher_prepared_statement('{"name": "Tobias"}');
+EXECUTE cypher_stored_procedure('{"name": "Tobias"}');
 ```
 


### PR DESCRIPTION
Based on the tutorial

First run this
```
PREPARE cypher_stored_procedure(agtype) AS
SELECT *
FROM cypher('expr', $$
    MATCH (v:Person) 
    WHERE v.name = $name
    RETURN v
$$, $1)
AS (v agtype);
```

Then run this
```
EXECUTE cypher_prepared_statement('{"name": "Tobias"}');
```

Will encounter an error
```
[42601] ERROR: syntax error at or near "cypher_prepared_statement"
```

If changed to this, it will work correctly.
```
EXECUTE cypher_stored_procedure('{"name": "Tobias"}');
```

This PR is identical to PR#105. The credit should go to the author of PR#105.