### PR TITLE
docs(RETURN): document pattern expressions in projections

### DIFF
--- a/docs/clauses/return.md
+++ b/docs/clauses/return.md
@@ -333,6 +333,75 @@ Result
 
 
 
+## Pattern expressions in projections
+
+A *pattern expression* is a path pattern, such as `(a)-[:KNOWS]->(:Person)`, used in a position where a value is expected. It evaluates to a boolean that is `true` when at least one matching path exists. In addition to being used as a predicate in a `WHERE` clause, a pattern expression can be returned directly from a `RETURN` (or `WITH`) projection.
+
+Query
+
+
+```postgresql
+SELECT *
+FROM cypher('graph_name', $$
+    MATCH (a:Person)
+    RETURN a.name, (a)-[:KNOWS]->(:Person) AS knows_someone
+    ORDER BY a.name
+$$) as (name agtype, knows_someone agtype);
+```
+
+
+For each person, this returns a boolean indicating whether they have an outgoing `KNOWS` relationship to another `Person`.
+
+Result
+
+
+<table>
+  <tr>
+   <td><strong>name</strong>
+   </td>
+   <td><strong>knows_someone</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>"A"
+   </td>
+   <td>true
+   </td>
+  </tr>
+  <tr>
+   <td>"B"
+   </td>
+   <td>true
+   </td>
+  </tr>
+  <tr>
+   <td>"C"
+   </td>
+   <td>true
+   </td>
+  </tr>
+  <tr>
+   <td>"D"
+   </td>
+   <td>false
+   </td>
+  </tr>
+  <tr>
+   <td>"D"
+   </td>
+   <td>false
+   </td>
+  </tr>
+  <tr>
+   <td colspan="2" >(5 rows)
+   </td>
+  </tr>
+</table>
+
+
+**Performance:** A pattern expression is evaluated as an `EXISTS` subquery. In a projection it is evaluated once for every row produced by the match, so its cost grows with the number of rows returned. Returning several pattern expressions, or returning them over a large result set, can be expensive on large graphs; where possible, narrow the result set with a `WHERE` clause before projecting pattern expressions.
+
+
 ## Unique results
 
 `DISTINCT` retrieves only unique records depending on the fields that have been selected to output.


### PR DESCRIPTION
**What** — Documents that pattern expressions (path patterns such as `(a)-[:KNOWS]->(:Person)`) can be returned directly from a `RETURN`/`WITH` projection, not only used as `WHERE` predicates. Adds a worked example to the RETURN reference with verified output, plus a performance note.

**Why** — Follow-up to the review of apache/age#2360. The reviewer asked that the per-row `EXISTS`-subquery cost of pattern expressions in projection contexts be discoverable from the Cypher reference, not just the PR history.

**Performance note** — A pattern expression is evaluated as an `EXISTS` subquery, once per result row in a projection, so cost scales with rows projected. The note makes only this mechanically-grounded claim.

**Depends on** apache/age#2360 (the projection capability); should not merge before it.

**Verification** — Example output generated against a PG18 build of the #2360 branch using the canonical doc graph (`intro/aggregation.md`).